### PR TITLE
fix: hardening — null check, tag truncation, 50-tag limit, expanded ignore list

### DIFF
--- a/infra/modules/functionApp.bicep
+++ b/infra/modules/functionApp.bicep
@@ -123,6 +123,26 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
           value: 'Microsoft.Network/frontdoor'
         }
         {
+          name: 'StamperConfig__IgnorePatterns__3'
+          value: 'Microsoft.Authorization/'
+        }
+        {
+          name: 'StamperConfig__IgnorePatterns__4'
+          value: 'Microsoft.Resources/subscriptions'
+        }
+        {
+          name: 'StamperConfig__IgnorePatterns__5'
+          value: 'Microsoft.ClassicCompute/'
+        }
+        {
+          name: 'StamperConfig__IgnorePatterns__6'
+          value: 'Microsoft.Insights/diagnosticSettings'
+        }
+        {
+          name: 'StamperConfig__IgnorePatterns__7'
+          value: 'Microsoft.Security/'
+        }
+        {
           name: 'StamperConfig__ConfigBlobUri'
           value: 'https://${storageAccountName}.blob.${environment().suffixes.storage}/config/stamper.json'
         }

--- a/src/AzStamper.Core/StampOrchestrator.cs
+++ b/src/AzStamper.Core/StampOrchestrator.cs
@@ -30,8 +30,14 @@ public class StampOrchestrator
         _logger = logger;
     }
 
-    public async Task ProcessAsync(ResourceEvent evt, CancellationToken cancellationToken = default)
+    public async Task ProcessAsync(ResourceEvent? evt, CancellationToken cancellationToken = default)
     {
+        if (evt is null)
+        {
+            _logger.LogWarning("ResourceEvent is null — skipping");
+            return;
+        }
+
         if (string.IsNullOrEmpty(evt.ResourceId))
         {
             _logger.LogWarning("Event has null or empty ResourceId — skipping");
@@ -134,12 +140,26 @@ public class StampOrchestrator
             }
 
             var value = ResolveTemplate(entry.Value, caller, timestamp, evt.PrincipalType);
+            if (value.Length > 256)
+            {
+                _logger.LogWarning("Tag '{Key}' value exceeds 256 chars ({Length}) — truncating", key, value.Length);
+                value = value[..256];
+            }
             tagsToApply[key] = value;
         }
 
         if (tagsToApply.Count == 0)
         {
             _logger.LogInformation("No new tags to apply to {ResourceId}", evt.ResourceId);
+            return;
+        }
+
+        // Azure enforces a 50-tag limit per resource
+        var totalTagCount = existingTags.Count + tagsToApply.Count(t => !existingTags.ContainsKey(t.Key));
+        if (totalTagCount > 50)
+        {
+            _logger.LogWarning("Skipping {ResourceId} — applying {NewCount} tag(s) would exceed the 50-tag limit (existing: {ExistingCount})",
+                evt.ResourceId, tagsToApply.Count, existingTags.Count);
             return;
         }
 

--- a/tests/AzStamper.Core.Tests/StampOrchestratorTests.cs
+++ b/tests/AzStamper.Core.Tests/StampOrchestratorTests.cs
@@ -420,4 +420,57 @@ public class StampOrchestratorTests
         Assert.Equal("bob@contoso.com", capturedTags["LastModifiedBy"]);
         Assert.False(capturedTags.ContainsKey("Creator"), "Creator should not be overwritten");
     }
+
+    [Fact]
+    public async Task SkipsWhenEventIsNull()
+    {
+        var orchestrator = CreateOrchestrator();
+
+        await orchestrator.ProcessAsync(null);
+
+        _tagService.Verify(x => x.GetTagsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TruncatesTagValuesExceeding256Chars()
+    {
+        var resourceId = "/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1";
+        var longCaller = new string('a', 300);
+        _tagService
+            .Setup(x => x.GetTagsAsync(resourceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string>());
+        _tagService
+            .Setup(x => x.SetTagsAsync(resourceId, It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var orchestrator = CreateOrchestrator();
+        var evt = new ResourceEvent { ResourceId = resourceId, Caller = longCaller };
+
+        await orchestrator.ProcessAsync(evt);
+
+        _tagService.Verify(x => x.SetTagsAsync(
+            resourceId,
+            It.Is<Dictionary<string, string>>(d =>
+                d["Creator"].Length == 256),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SkipsWhenTagCountWouldExceed50()
+    {
+        var resourceId = "/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1";
+        var existingTags = Enumerable.Range(0, 48)
+            .ToDictionary(i => $"ExistingTag{i}", i => $"value{i}");
+        _tagService
+            .Setup(x => x.GetTagsAsync(resourceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingTags);
+
+        var orchestrator = CreateOrchestrator();
+        var evt = new ResourceEvent { ResourceId = resourceId, Caller = "alice@contoso.com" };
+
+        await orchestrator.ProcessAsync(evt);
+
+        _tagService.Verify(x => x.SetTagsAsync(
+            It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
 }


### PR DESCRIPTION
## Summary

Four hardening fixes for tag processing robustness:

- **#17**: Null check for `ResourceEvent` parameter — prevents NRE if event parsing fails
- **#16**: Truncate tag values exceeding Azure's 256-character limit — logs a warning and truncates instead of failing the API call
- **#15**: Skip tagging when total count would exceed Azure's 50-tag limit — prevents `RequestFailedException` on heavily-tagged resources
- **#14**: Expanded default ignore list with untaggable resource types: `Microsoft.Authorization/`, `Microsoft.Resources/subscriptions`, `Microsoft.ClassicCompute/`, `Microsoft.Insights/diagnosticSettings`, `Microsoft.Security/`

## Test plan

- [x] `dotnet test Az-Stamper.sln` — 47/47 passing (3 new tests)
- [x] `az bicep build --file infra/main.bicep` — validates

Closes #14, #15, #16, #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)