### PR TITLE
fix: CSP compliance — move inline scripts to external files

### DIFF
--- a/swa/index.html
+++ b/swa/index.html
@@ -16,7 +16,7 @@
       <div class="tab" data-tab="activity">Activity</div>
     </nav>
     <div class="header-user" id="user-info">
-      <button class="btn btn-primary" id="sign-in-btn" onclick="signIn()">Sign In</button>
+      <button class="btn btn-primary" id="sign-in-btn" data-action="sign-in">Sign In</button>
     </div>
   </header>
 
@@ -24,7 +24,7 @@
     <div id="sign-in-prompt" class="sign-in-prompt">
       <h2>Welcome to Az-Stamper Config</h2>
       <p style="color: var(--text-secondary);">Sign in with your Azure account to manage tag configuration.</p>
-      <button class="btn btn-primary btn-lg" onclick="signIn()">Sign In with Microsoft</button>
+      <button class="btn btn-primary btn-lg" data-action="sign-in">Sign In with Microsoft</button>
     </div>
 
     <div id="app-content" style="display:none;">
@@ -38,13 +38,7 @@
   <div id="modal-container"></div>
   <div class="toast-container" id="toast-container"></div>
 
-  <script>
-    window.AZ_STAMPER_CONFIG = {
-      clientId: '00ec1874-7c53-406b-a0a4-85d41daf2453',
-      tenantId: 'dbb4b808-f0e6-469f-92d6-9788aef52734',
-      configBlobUrl: 'https://stazstamper.blob.core.windows.net/config/stamper.json'
-    };
-  </script>
+  <script src="/js/app-config.js"></script>
   <script src="https://alcdn.msauth.net/browser/2.38.3/js/msal-browser.min.js"></script>
   <script src="/js/utils.js"></script>
   <script src="/js/auth.js"></script>
@@ -53,18 +47,6 @@
   <script src="/js/tabs/rules.js"></script>
   <script src="/js/tabs/simulate.js"></script>
   <script src="/js/tabs/activity.js"></script>
-
-  <script>
-    document.querySelectorAll('.tab').forEach(tab => {
-      tab.addEventListener('click', () => {
-        document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
-        document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
-        tab.classList.add('active');
-        document.getElementById('panel-' + tab.dataset.tab).classList.add('active');
-        const loadFn = window['load' + tab.dataset.tab.charAt(0).toUpperCase() + tab.dataset.tab.slice(1) + 'Tab'];
-        if (loadFn) loadFn();
-      });
-    });
-  </script>
+  <script src="/js/app-init.js"></script>
 </body>
 </html>

--- a/swa/js/app-config.js
+++ b/swa/js/app-config.js
@@ -1,0 +1,6 @@
+// App configuration — loaded before all other scripts
+window.AZ_STAMPER_CONFIG = {
+  clientId: '00ec1874-7c53-406b-a0a4-85d41daf2453',
+  tenantId: 'dbb4b808-f0e6-469f-92d6-9788aef52734',
+  configBlobUrl: 'https://stazstamper.blob.core.windows.net/config/stamper.json'
+};

--- a/swa/js/app-init.js
+++ b/swa/js/app-init.js
@@ -1,0 +1,19 @@
+// App initialization — wires up tab switching and sign-in buttons
+// Loaded after all other scripts
+
+// Tab switcher
+document.querySelectorAll('.tab').forEach(function(tab) {
+  tab.addEventListener('click', function() {
+    document.querySelectorAll('.tab').forEach(function(t) { t.classList.remove('active'); });
+    document.querySelectorAll('.tab-panel').forEach(function(p) { p.classList.remove('active'); });
+    tab.classList.add('active');
+    document.getElementById('panel-' + tab.dataset.tab).classList.add('active');
+    var loadFn = window['load' + tab.dataset.tab.charAt(0).toUpperCase() + tab.dataset.tab.slice(1) + 'Tab'];
+    if (loadFn) loadFn();
+  });
+});
+
+// Sign-in buttons
+document.querySelectorAll('[data-action="sign-in"]').forEach(function(btn) {
+  btn.addEventListener('click', function() { signIn(); });
+});


### PR DESCRIPTION
## Summary
- CSP `script-src 'self'` was blocking inline `<script>` blocks and `onclick` handlers
- Extracted `AZ_STAMPER_CONFIG` to `swa/js/app-config.js`
- Extracted tab switcher and sign-in button wiring to `swa/js/app-init.js`
- Replaced `onclick="signIn()"` with `data-action="sign-in"` attributes bound in `app-init.js`
- Zero inline scripts remain in `index.html`

## Test plan
- [ ] No CSP violations in browser console
- [ ] Sign in button triggers MSAL auth flow
- [ ] Tab switching works

🤖 Generated with [Claude Code](https://claude.com/claude-code)