### PR TITLE
fix: switch MSAL CDN to unpkg (alcdn.msauth.net returns 404)

### DIFF
--- a/swa/index.html
+++ b/swa/index.html
@@ -39,7 +39,7 @@
   <div class="toast-container" id="toast-container"></div>
 
   <script src="/js/app-config.js"></script>
-  <script src="https://alcdn.msauth.net/browser/2.38.3/js/msal-browser.min.js"></script>
+  <script src="https://unpkg.com/@azure/msal-browser@5.6.2/lib/msal-browser.min.js"></script>
   <script src="/js/utils.js"></script>
   <script src="/js/auth.js"></script>
   <script src="/js/config.js"></script>

--- a/swa/staticwebapp.config.json
+++ b/swa/staticwebapp.config.json
@@ -3,6 +3,6 @@
     "rewrite": "/index.html"
   },
   "globalHeaders": {
-    "Content-Security-Policy": "default-src 'self'; script-src 'self' https://alcdn.msauth.net; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.blob.core.windows.net https://management.azure.com https://api.loganalytics.io https://login.microsoftonline.com https://graph.microsoft.com"
+    "Content-Security-Policy": "default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.blob.core.windows.net https://management.azure.com https://api.loganalytics.io https://login.microsoftonline.com https://graph.microsoft.com"
   }
 }


### PR DESCRIPTION
## Summary
- `alcdn.msauth.net/browser/2.38.3/js/msal-browser.min.js` returns 404 — CDN no longer serves this version
- Switched to `unpkg.com/@azure/msal-browser@5.6.2` (same UMD global `msal`, same API surface)
- Updated CSP `script-src` to allow `https://unpkg.com`

## Root cause
MSAL library silently failed to load, so `msalInstance` stayed null, and clicking Sign In triggered the "Authentication not configured" alert.

## Test plan
- [ ] MSAL library loads (console: `typeof msal` returns `"object"`)
- [ ] Sign In button triggers Entra ID redirect
- [ ] No CSP violations in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)