### PR TITLE
fix: MSAL v5 requires initialize() before use

### DIFF
--- a/swa/js/auth.js
+++ b/swa/js/auth.js
@@ -34,7 +34,9 @@ function initAuth() {
 
   msalInstance = new msal.PublicClientApplication(msalConfig);
 
-  msalInstance.handleRedirectPromise().then(response => {
+  msalInstance.initialize().then(() => {
+    return msalInstance.handleRedirectPromise();
+  }).then(response => {
     if (response) {
       currentAccount = response.account;
     } else {


### PR DESCRIPTION
## Summary
- MSAL v5 requires `await instance.initialize()` before calling `handleRedirectPromise()` or any other method
- Added `initialize().then(...)` chain before `handleRedirectPromise()` in `auth.js`

## Test plan
- [ ] No `uninitialized_public_client_application` error in console
- [ ] Sign In button redirects to Microsoft login

🤖 Generated with [Claude Code](https://claude.com/claude-code)