### PR TITLE
fix: CSP img-src allow data: URIs for select arrows

### DIFF
--- a/swa/staticwebapp.config.json
+++ b/swa/staticwebapp.config.json
@@ -3,6 +3,6 @@
     "rewrite": "/index.html"
   },
   "globalHeaders": {
-    "Content-Security-Policy": "default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.blob.core.windows.net https://management.azure.com https://api.loganalytics.io https://login.microsoftonline.com https://graph.microsoft.com"
+    "Content-Security-Policy": "default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://*.blob.core.windows.net https://management.azure.com https://api.loganalytics.io https://login.microsoftonline.com https://graph.microsoft.com"
   }
 }


### PR DESCRIPTION
## Summary
- CSS select dropdown arrow uses an inline SVG data URI, blocked by `default-src 'self'`
- Add `img-src 'self' data:` to CSP headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)