### PR TITLE
feat: add App Insights ID to SWA config for Activity tab

### DIFF
--- a/swa/js/app-config.js
+++ b/swa/js/app-config.js
@@ -2,5 +2,6 @@
 window.AZ_STAMPER_CONFIG = {
   clientId: '00ec1874-7c53-406b-a0a4-85d41daf2453',
   tenantId: 'dbb4b808-f0e6-469f-92d6-9788aef52734',
-  configBlobUrl: 'https://stazstamper.blob.core.windows.net/config/stamper.json'
+  configBlobUrl: 'https://stazstamper.blob.core.windows.net/config/stamper.json',
+  appInsightsId: '/subscriptions/2f2d900c-03a4-4763-8138-bed4d299a7fa/resourceGroups/rg-az-stamper/providers/microsoft.insights/components/appi-az-stamper'
 };


### PR DESCRIPTION
## Summary
- Add `appInsightsId` to `app-config.js` pointing to `appi-az-stamper`
- Enables the Activity tab to query stamping events via ARM-proxied query API

## Test plan
- [ ] Activity tab loads without "not configured" message
- [ ] Query returns results (or empty table if no events yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)