### PR TITLE
fix: improve dark mode contrast on tag-existing chips

### DIFF
--- a/swa/css/styles.css
+++ b/swa/css/styles.css
@@ -486,8 +486,8 @@ tbody tr:hover {
 }
 
 .tag-existing {
-  background: rgba(136, 136, 170, 0.15);
-  color: var(--text-secondary);
+  background: rgba(136, 136, 170, 0.22);
+  color: #b0b0cc;
   border: 1px solid var(--border);
 }
 


### PR DESCRIPTION
## Summary
- Bumped `.tag-existing` chip text color from `#8888aa` → `#b0b0cc` and background opacity from `0.15` → `0.22`
- Raises WCAG contrast ratio from ~3.85:1 to ~5.6:1 (passes AA for small text at 0.75rem)

Closes #53

## Test plan
- [ ] Open SWA → Tag Rules tab, verify existing-tag chips are readable against dark background
- [ ] Check Simulate tab tag chips still render correctly
- [ ] Verify no visual regression on other chip types (`.tag-new`, `.tag-excluded`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)