### PR TITLE
feat: automate SelfPrincipalId setting in deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,11 +42,21 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy infrastructure
+        id: infra
         run: |
-          az deployment group create \
+          result=$(az deployment group create \
             --resource-group ${{ vars.RESOURCE_GROUP }} \
             --template-file infra/main.bicep \
-            --parameters infra/parameters/${{ inputs.environment }}.bicepparam
+            --parameters infra/parameters/${{ inputs.environment }}.bicepparam \
+            --query 'properties.outputs.principalId.value' -o tsv)
+          echo "principalId=$result" >> "$GITHUB_OUTPUT"
+
+      - name: Set SelfPrincipalId app setting
+        run: |
+          az functionapp config appsettings set \
+            --resource-group ${{ vars.RESOURCE_GROUP }} \
+            --name ${{ vars.FUNCTION_APP_NAME }} \
+            --settings "StamperConfig__SelfPrincipalId=${{ steps.infra.outputs.principalId }}"
 
       - name: Deploy function code
         run: |


### PR DESCRIPTION
## Summary
- Captures `principalId` from Bicep deployment output using `--query` and `GITHUB_OUTPUT`
- Adds post-deployment step to set `StamperConfig__SelfPrincipalId` app setting via `az functionapp config appsettings set`
- Activates the recursive loop prevention in `StampOrchestrator` — the function now skips events triggered by its own managed identity

**Why pipeline, not Bicep?** The function app's `identity.principalId` can't be referenced in its own `appSettings` (circular dependency). Using `az functionapp config appsettings set` after deployment is additive and avoids replacing existing settings.

Closes #35

## Test plan
- [ ] Run deploy workflow in dev environment
- [ ] Verify `StamperConfig__SelfPrincipalId` appears in Function App → Configuration → App Settings
- [ ] Verify the value matches the function app's managed identity Object ID in Entra ID
- [ ] Trigger a resource write — confirm the function skips self-triggered tag-write events in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)