### PR TITLE
feat: Azure Workbook dashboard for tag monitoring

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -7,6 +7,7 @@ param appInsightsName string
 param logAnalyticsName string = '${functionAppName}-law'
 param environment string = 'dev'
 param swaName string = '${functionAppName}-config'
+param workbookName string = 'Az-Stamper Activity Dashboard'
 param tags object = {
   Project: 'Az-Stamper'
   ManagedBy: 'Bicep'
@@ -74,6 +75,17 @@ resource storageAccountRef 'Microsoft.Storage/storageAccounts@2023-05-01' existi
   name: storageAccountName
 }
 
+
+// Azure Workbook for tag monitoring dashboard
+module workbook 'modules/workbook.bicep' = {
+  name: 'workbook'
+  params: {
+    name: workbookName
+    location: location
+    tags: tags
+    appInsightsId: monitoring.outputs.appInsightsId
+  }
+}
 
 // Static Web App for config management UI
 module swa 'modules/swa.bicep' = {

--- a/infra/modules/workbook-template.json
+++ b/infra/modules/workbook-template.json
@@ -1,0 +1,154 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "time-range",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "type": 4,
+            "typeSettings": {
+              "selectableValues": [
+                { "durationMs": 3600000, "displayName": "Last 1 hour" },
+                { "durationMs": 86400000, "displayName": "Last 24 hours" },
+                { "durationMs": 604800000, "displayName": "Last 7 days" },
+                { "durationMs": 2592000000, "displayName": "Last 30 days" }
+              ],
+              "allowCustom": true
+            },
+            "value": { "durationMs": 86400000 }
+          }
+        ]
+      },
+      "name": "parameters"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "# Az-Stamper Activity Dashboard\nMonitor tag stamping activity, success rates, and errors across enrolled subscriptions."
+      },
+      "name": "header"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where timestamp {TimeRange}\n| where message startswith \"Stamped\"\n| extend SubscriptionId = tostring(customDimensions.SubscriptionId)\n| summarize\n    TagsApplied = sum(toint(customDimensions.Count)),\n    ResourcesStamped = dcount(tostring(customDimensions.ResourceId)),\n    LastActivity = max(timestamp)\n  by SubscriptionId\n| order by ResourcesStamped desc",
+        "size": 1,
+        "title": "Active Subscriptions",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "table",
+        "gridSettings": {
+          "formatters": [
+            { "columnMatch": "TagsApplied", "formatter": 4, "formatOptions": { "palette": "blue" } },
+            { "columnMatch": "ResourcesStamped", "formatter": 4, "formatOptions": { "palette": "green" } },
+            { "columnMatch": "LastActivity", "formatter": 6, "formatOptions": { "dateFormat": { "formatName": "shortDateTimePattern" } } }
+          ]
+        }
+      },
+      "name": "active-subscriptions"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where timestamp {TimeRange}\n| where message startswith \"Stamped\" or message startswith \"Failed to stamp\" or message startswith \"Skipping\"\n| extend SubscriptionId = tostring(customDimensions.SubscriptionId)\n| extend Status = case(\n    message startswith \"Stamped\", \"Success\",\n    message startswith \"Failed\", \"Failed\",\n    \"Skipped\")\n| summarize Count = count() by SubscriptionId, Status\n| order by SubscriptionId asc, Status asc",
+        "size": 1,
+        "title": "Tag Success / Failure / Skip Rates by Subscription",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart",
+        "chartSettings": {
+          "xAxis": "SubscriptionId",
+          "yAxis": [ "Count" ],
+          "group": "Status",
+          "seriesLabelSettings": [
+            { "seriesName": "Success", "color": "green" },
+            { "seriesName": "Failed", "color": "red" },
+            { "seriesName": "Skipped", "color": "yellow" }
+          ]
+        }
+      },
+      "name": "success-failure-rates"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where timestamp {TimeRange}\n| where message startswith \"Stamped\"\n| extend ResourceType = tostring(customDimensions.ResourceType)\n| summarize\n    ResourcesStamped = dcount(tostring(customDimensions.ResourceId)),\n    TotalTags = sum(toint(customDimensions.Count))\n  by ResourceType\n| top 15 by ResourcesStamped desc",
+        "size": 1,
+        "title": "Most-Tagged Resource Types",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart",
+        "chartSettings": {
+          "xAxis": "ResourceType",
+          "yAxis": [ "ResourcesStamped" ]
+        }
+      },
+      "name": "top-resource-types"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where timestamp {TimeRange}\n| where severityLevel >= 2\n| where message !startswith \"Skipping self-triggered\"\n| extend ResourceId = tostring(customDimensions.ResourceId)\n| extend ResourceType = tostring(customDimensions.ResourceType)\n| extend Reason = case(\n    message has \"ignore pattern\", strcat(\"Ignore pattern: \", tostring(customDimensions.Pattern)),\n    message has \"50-tag limit\", \"Tag limit exceeded\",\n    message has \"Cannot resolve caller\", \"Caller unresolvable\",\n    message has \"Could not read tags\", \"Tag read failed\",\n    message has \"Failed to stamp\", \"Stamp failed\",\n    message has \"disabled\", \"Subscription disabled\",\n    message)\n| project timestamp, ResourceId, ResourceType, Reason\n| order by timestamp desc\n| take 100",
+        "size": 1,
+        "title": "Errors & Skipped Resources",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "table",
+        "gridSettings": {
+          "formatters": [
+            { "columnMatch": "timestamp", "formatter": 6, "formatOptions": { "dateFormat": { "formatName": "shortDateTimePattern" } } },
+            { "columnMatch": "Reason", "formatter": 1 }
+          ]
+        }
+      },
+      "name": "errors-skipped"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where timestamp {TimeRange}\n| where message startswith \"Stamped\" or message startswith \"Failed to stamp\"\n| extend Status = iff(message startswith \"Stamped\", \"Success\", \"Failed\")\n| summarize Count = count() by bin(timestamp, 1h), Status\n| order by timestamp asc",
+        "size": 0,
+        "title": "Tagging Activity Timeline",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "timechart",
+        "chartSettings": {
+          "seriesLabelSettings": [
+            { "seriesName": "Success", "color": "green" },
+            { "seriesName": "Failed", "color": "red" }
+          ]
+        }
+      },
+      "name": "activity-timeline"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where timestamp {TimeRange}\n| where message startswith \"Stamped\"\n| extend Caller = tostring(customDimensions.Caller)\n| summarize ResourcesStamped = dcount(tostring(customDimensions.ResourceId)) by Caller\n| top 10 by ResourcesStamped desc",
+        "size": 1,
+        "title": "Top Callers (Who Triggered Stamping)",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "table",
+        "gridSettings": {
+          "formatters": [
+            { "columnMatch": "ResourcesStamped", "formatter": 4, "formatOptions": { "palette": "blue" } }
+          ]
+        }
+      },
+      "name": "top-callers"
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/infra/modules/workbook.bicep
+++ b/infra/modules/workbook.bicep
@@ -1,0 +1,21 @@
+param name string
+param location string
+param tags object
+param appInsightsId string
+
+var workbookId = guid(name, resourceGroup().id, 'az-stamper-workbook')
+
+resource workbook 'Microsoft.Insights/workbooks@2023-06-01' = {
+  name: workbookId
+  location: location
+  tags: tags
+  kind: 'shared'
+  properties: {
+    displayName: name
+    category: 'workbook'
+    sourceId: appInsightsId
+    serializedData: loadTextContent('workbook-template.json')
+  }
+}
+
+output workbookId string = workbook.id


### PR DESCRIPTION
## Summary
- Adds a shared Azure Workbook template (`infra/modules/workbook-template.json`) with 6 KQL-based panels
- Deploys via new `workbook.bicep` module, wired into `main.bicep`
- Queries the existing Application Insights `traces` table using structured log properties from `StampOrchestrator`

**Dashboard Panels:**
| Panel | Visualization | Data Source |
|-------|--------------|-------------|
| Active Subscriptions | Table | Distinct sub IDs, tag counts, last activity |
| Success/Failure/Skip Rates | Bar chart | Grouped by subscription and outcome |
| Most-Tagged Resource Types | Bar chart | Top 15 by distinct resource count |
| Errors & Skipped Resources | Table | Warnings with parsed reason column |
| Activity Timeline | Time chart | Hourly success vs. failure counts |
| Top Callers | Table | Who triggered the most stamping |

Closes #33

## Test plan
- [ ] `az bicep build --file infra/main.bicep` compiles without errors
- [ ] Deploy to dev — workbook appears in Azure Portal under Application Insights → Workbooks
- [ ] Each panel renders data after triggering some resource writes
- [ ] Time range parameter filters all panels correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)