### PR TITLE
fix: sprint 5 bugs — enrollment detection, chip contrast, activity API

### DIFF
--- a/swa/css/styles.css
+++ b/swa/css/styles.css
@@ -486,9 +486,9 @@ tbody tr:hover {
 }
 
 .tag-existing {
-  background: rgba(136, 136, 170, 0.22);
-  color: #b0b0cc;
-  border: 1px solid var(--border);
+  background: rgba(136, 136, 170, 0.30);
+  color: #d0d0e8;
+  border: 1px solid rgba(136, 136, 170, 0.45);
 }
 
 .tag-new {

--- a/swa/js/tabs/activity.js
+++ b/swa/js/tabs/activity.js
@@ -138,7 +138,7 @@ async function refreshActivity() {
       '| take 100',
     ].join('\n');
 
-    var url = 'https://management.azure.com' + appInsightsId + '/query?api-version=2019-08-01-preview';
+    var url = 'https://management.azure.com' + appInsightsId + '/query?api-version=2018-04-20';
 
     var data = await azureFetch(url, token, {
       method: 'POST',

--- a/swa/js/tabs/subscriptions.js
+++ b/swa/js/tabs/subscriptions.js
@@ -69,22 +69,22 @@ function renderSubscriptionsTab() {
     empty.appendChild(emptyTitle);
     empty.appendChild(emptyDesc);
     panel.appendChild(empty);
-    return;
+  } else {
+    // Card grid
+    const grid = document.createElement('div');
+    grid.className = 'card-grid';
+
+    subIds.forEach(function(subId) {
+      const sub = subs[subId];
+      const card = buildSubscriptionCard(subId, sub);
+      grid.appendChild(card);
+    });
+
+    panel.appendChild(grid);
   }
 
-  // Card grid
-  const grid = document.createElement('div');
-  grid.className = 'card-grid';
-
-  subIds.forEach(function(subId) {
-    const sub = subs[subId];
-    const card = buildSubscriptionCard(subId, sub);
-    grid.appendChild(card);
-  });
-
-  panel.appendChild(grid);
-
   // Discovered (enrolled but not configured) section — populated by verifyAllEnrollments
+  // Must be created even when config is empty so discovery has a render target
   const discoveredSection = document.createElement('div');
   discoveredSection.id = 'discovered-subs-section';
   panel.appendChild(discoveredSection);
@@ -512,8 +512,8 @@ async function verifyAllEnrollments() {
       el.title = 'Event Grid system topic found';
     } else {
       el.className = 'badge badge-warning';
-      el.textContent = 'Config Only';
-      el.title = 'No Event Grid system topic found — run enroll.bicep to deploy';
+      el.textContent = 'No Event Grid';
+      el.title = 'In config but no Event Grid system topic deployed — run enroll.bicep to enable tagging';
     }
   });
 
@@ -544,10 +544,10 @@ async function checkEventGridEnrollment(subId, token) {
   var data = await azureFetch(url, token);
   var topics = (data && data.value) ? data.value : [];
 
-  // Look for a system topic sourced from this subscription
+  // Look for a system topic sourced from this subscription (case-insensitive)
   return topics.some(function(topic) {
-    return topic.properties &&
-      topic.properties.topicType === 'Microsoft.Resources.Subscriptions';
+    var topicType = (topic.properties && topic.properties.topicType) || '';
+    return topicType.toLowerCase() === 'microsoft.resources.subscriptions';
   });
 }
 


### PR DESCRIPTION
## Summary
Fixes 6 bugs reported after Sprint 5 merge:

| # | Bug | Fix |
|---|-----|-----|
| 1 | Verify on empty config — discovered section missing | Moved `discovered-subs-section` div before empty-state early return |
| 2 | sub-lab shows "Config Only" despite having Event Grid | Case-insensitive `topicType` comparison in `checkEventGridEnrollment` |
| 3 | "Config Only" label confusing | Renamed to "No Event Grid" with clearer tooltip |
| 4 | Tag chips still washed out in dark mode | Bumped to `#d0d0e8` text, `0.30` bg opacity, visible border |
| 5 | Activity tab 400 error | Changed API version from `2019-08-01-preview` to `2018-04-20` |

## Test plan
- [ ] Remove all subs from config, click Verify — discovered section renders below empty state
- [ ] Both sub-lab and sub-galvnyz-web show "Enrolled" (green) after verify
- [ ] Tag Rules chips are clearly readable in dark mode
- [ ] Simulate page existing tag chips are readable
- [ ] Activity tab loads events without API error

🤖 Generated with [Claude Code](https://claude.com/claude-code)