### PR TITLE
fix: enrollment SWA bugs — redeclared var, KQL, fail-open, styling

### DIFF
--- a/swa/css/styles.css
+++ b/swa/css/styles.css
@@ -304,10 +304,12 @@ ul, ol {
   justify-content: center;
   gap: 6px;
   padding: 6px 16px;
+  background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius);
   font-size: 0.875rem;
   font-weight: 500;
+  color: var(--text-primary);
   cursor: pointer;
   white-space: nowrap;
   transition: background var(--transition), border-color var(--transition),

--- a/swa/js/enrollment.js
+++ b/swa/js/enrollment.js
@@ -109,7 +109,13 @@ async function checkEnrollmentDetail(subId, token) {
     esData = await azureFetch(esUrl, token);
   } catch (err) {
     console.error('Failed to list event subscriptions for topic ' + topicId + ':', err);
-    return null;
+    // Fail-open: topic exists, assume active even if we can't list event subscriptions
+    return {
+      active: true,
+      systemTopicName: systemTopicName,
+      systemTopicRg: systemTopicRg,
+      eventSubscriptionName: null,
+    };
   }
 
   var eventSubs = (esData && esData.value) ? esData.value : [];

--- a/swa/js/tabs/activity.js
+++ b/swa/js/tabs/activity.js
@@ -1,6 +1,6 @@
 // Activity Tab — recent tagging events from Application Insights
 
-var _activityTimeRange = 'P1D';
+var _activityTimeRange = '1d';
 
 // ── Entry point ───────────────────────────────────────────────────────────────
 
@@ -45,9 +45,9 @@ function renderActivityControls() {
   rangeSelect.style.cssText = 'width:auto;padding:6px 10px;font-size:0.875rem;';
 
   var rangeOptions = [
-    { value: 'PT1H', label: 'Last 1 hour' },
-    { value: 'P1D',  label: 'Last 24 hours' },
-    { value: 'P7D',  label: 'Last 7 days' },
+    { value: '1h',  label: 'Last 1 hour' },
+    { value: '1d',  label: 'Last 24 hours' },
+    { value: '7d',  label: 'Last 7 days' },
   ];
 
   rangeOptions.forEach(function(opt) {

--- a/swa/js/tabs/rules.js
+++ b/swa/js/tabs/rules.js
@@ -216,9 +216,9 @@ function renderRulesTab(selectedSubId) {
   var subConfig = configSubs[selectedSubId];
 
   // ── Section A: Global Defaults (read-only) ────────────────────────────────
-  const globalSection = buildSection('Global Defaults', 'Applied to all resources. Read-only — configure per-subscription overrides below.');
+  var globalSection2 = buildSection('Global Defaults', 'Applied to all resources. Read-only — configure per-subscription overrides below.');
 
-  const globalDefaults = [
+  var globalDefaults2 = [
     { name: 'Creator',        value: '{caller}',    overwrite: false },
     { name: 'CreatedOn',      value: '{timestamp}', overwrite: false },
     { name: 'LastModifiedBy', value: '{caller}',    overwrite: true  },
@@ -226,10 +226,10 @@ function renderRulesTab(selectedSubId) {
     { name: 'StampedBy',      value: 'Az-Stamper',  overwrite: false },
   ];
 
-  const globalBody = globalSection.querySelector('.rules-section-body');
+  var globalBody2 = globalSection2.querySelector('.rules-section-body');
 
-  globalDefaults.forEach(function(def) {
-    const row = document.createElement('div');
+  globalDefaults2.forEach(function(def) {
+    var row = document.createElement('div');
     row.className = 'rule-row';
 
     const keyEl = document.createElement('div');
@@ -241,20 +241,20 @@ function renderRulesTab(selectedSubId) {
     valueEl.style.fontFamily = 'monospace';
     valueEl.textContent = def.value;
 
-    const overwriteChip = document.createElement('span');
+    var overwriteChip = document.createElement('span');
     overwriteChip.className = 'tag-chip ' + (def.overwrite ? 'tag-new' : 'tag-existing');
     overwriteChip.textContent = def.overwrite ? 'overwrite: true' : 'overwrite: false';
 
     row.appendChild(keyEl);
     row.appendChild(valueEl);
     row.appendChild(overwriteChip);
-    globalBody.appendChild(row);
+    globalBody2.appendChild(row);
   });
 
-  panel.appendChild(globalSection);
+  panel.appendChild(globalSection2);
 
   // ── Section B: Subscription Overrides (editable) ─────────────────────────
-  const overridesSection = buildSection(
+  var overridesSection = buildSection(
     'Subscription Overrides',
     'Per-subscription tag overrides that extend or replace global defaults for: ' +
     ((subConfig.displayName || '').trim() || selectedSubId)

--- a/swa/js/tabs/subscriptions.js
+++ b/swa/js/tabs/subscriptions.js
@@ -55,7 +55,7 @@ function renderSubscriptionsTab(enrolled) {
 
   var bannerDesc = document.createElement('span');
   bannerDesc.style.cssText = 'color:var(--text-secondary);font-size:0.875rem;margin-left:8px;';
-  bannerDesc.textContent = 'Applied to all enrolled subscriptions: CreatedBy, CreatedDate, CreatedByObjectId, Environment, ManagedBy.';
+  bannerDesc.textContent = 'Applied to all enrolled subscriptions unless overridden by a custom config.';
 
   var bannerLink = document.createElement('a');
   bannerLink.href = '#';


### PR DESCRIPTION
## Summary
Fixes 5 bugs from the enrollment-centric SWA redesign:

| Bug | Fix |
|-----|-----|
| Tag Rules blank page | `const globalSection` redeclared — renamed second instance to `globalSection2` |
| sub-lab not showing | Event subscription listing failure returned `null` — now fail-open (show as active) |
| Activity tab KQL error | ISO 8601 durations (`P1D`) don't work in KQL — changed to timespan literals (`1d`) |
| Banner shows wrong tag names | Removed hardcoded tag names, made description generic |
| Remove Custom Config white bg | Added `background:transparent` to `.btn` base class |

## Test plan
- [ ] Tag Rules tab loads and shows dropdown
- [ ] Both sub-lab and sub-galvnyz-web appear on Subscriptions tab
- [ ] Activity tab loads without KQL error
- [ ] "Remove Custom Config" button has transparent background
- [ ] Global defaults banner shows generic text

🤖 Generated with [Claude Code](https://claude.com/claude-code)