### PR TITLE
fix: register Application Insights telemetry in isolated worker

### DIFF
--- a/src/AzStamper.Functions/AzStamper.Functions.csproj
+++ b/src/AzStamper.Functions/AzStamper.Functions.csproj
@@ -9,7 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.50.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventGrid" Version="3.6.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />

--- a/src/AzStamper.Functions/Program.cs
+++ b/src/AzStamper.Functions/Program.cs
@@ -5,12 +5,16 @@ using Azure.Storage.Blobs;
 using AzStamper.Core;
 using AzStamper.Core.Models;
 using AzStamper.Core.Services;
+using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Graph;
 
 var builder = FunctionsApplication.CreateBuilder(args);
+
+builder.Services.AddApplicationInsightsTelemetryWorkerService();
+builder.Services.ConfigureFunctionsApplicationInsights();
 
 builder.Services.Configure<StamperConfig>(
     builder.Configuration.GetSection("StamperConfig"));


### PR DESCRIPTION
## Summary
- Adds `Microsoft.ApplicationInsights.WorkerService` and `Microsoft.Azure.Functions.Worker.ApplicationInsights` NuGet packages
- Registers telemetry services in `Program.cs` so `ILogger<T>` output flows to Application Insights
- Root cause: .NET isolated worker functions don't get automatic AI telemetry like the in-process model — explicit SDK registration is required

Closes #99

## Test plan
- [ ] Deploy function app to Azure
- [ ] Trigger an Event Grid event (resource write in enrolled subscription)
- [ ] Open Application Insights > Transaction Search — confirm request + trace telemetry appears
- [ ] Verify Activity tab in SWA Config UI shows recent stamp operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)