### PR TITLE
feat: Sprint 15 — tag compliance dashboard and policy enforcement

### DIFF
--- a/src/AzStamper.Core/Models/CompliancePolicy.cs
+++ b/src/AzStamper.Core/Models/CompliancePolicy.cs
@@ -1,0 +1,17 @@
+namespace AzStamper.Core.Models;
+
+public class CompliancePolicy
+{
+    public string Name { get; set; } = "Default";
+    public bool Enabled { get; set; } = true;
+    public List<RequiredTag> RequiredTags { get; set; } = new();
+    public List<string> ResourceTypeScope { get; set; } = new();
+    public string EnforcementMode { get; set; } = "audit";
+}
+
+public class RequiredTag
+{
+    public string Name { get; set; } = string.Empty;
+    public List<string>? AllowedValues { get; set; }
+    public string? Pattern { get; set; }
+}

--- a/src/AzStamper.Core/Models/ComplianceViolation.cs
+++ b/src/AzStamper.Core/Models/ComplianceViolation.cs
@@ -1,0 +1,8 @@
+namespace AzStamper.Core.Models;
+
+public class ComplianceViolation
+{
+    public string PolicyName { get; set; } = string.Empty;
+    public string TagName { get; set; } = string.Empty;
+    public string Reason { get; set; } = string.Empty;
+}

--- a/src/AzStamper.Core/Models/SubscriptionConfig.cs
+++ b/src/AzStamper.Core/Models/SubscriptionConfig.cs
@@ -7,4 +7,5 @@ public class SubscriptionConfig
     public Dictionary<string, TagEntry> TagOverrides { get; set; } = new();
     public Dictionary<string, ResourceTypeRule> ResourceTypeRules { get; set; } = new();
     public List<string> AdditionalIgnorePatterns { get; set; } = new();
+    public List<CompliancePolicy> CompliancePolicies { get; set; } = new();
 }

--- a/src/AzStamper.Core/Services/ComplianceEvaluator.cs
+++ b/src/AzStamper.Core/Services/ComplianceEvaluator.cs
@@ -1,0 +1,82 @@
+using System.Text.RegularExpressions;
+using AzStamper.Core.Models;
+
+namespace AzStamper.Core.Services;
+
+public class ComplianceEvaluator
+{
+    public List<ComplianceViolation> Evaluate(
+        Dictionary<string, string> currentTags,
+        List<CompliancePolicy> policies,
+        string resourceType)
+    {
+        var violations = new List<ComplianceViolation>();
+
+        foreach (var policy in policies)
+        {
+            if (!policy.Enabled)
+                continue;
+
+            // Check resource type scope — empty means all types
+            if (policy.ResourceTypeScope.Count > 0)
+            {
+                var inScope = policy.ResourceTypeScope
+                    .Any(s => string.Equals(s, resourceType, StringComparison.OrdinalIgnoreCase));
+                if (!inScope)
+                    continue;
+            }
+
+            foreach (var req in policy.RequiredTags)
+            {
+                if (!currentTags.TryGetValue(req.Name, out var tagValue))
+                {
+                    violations.Add(new ComplianceViolation
+                    {
+                        PolicyName = policy.Name,
+                        TagName = req.Name,
+                        Reason = "missing"
+                    });
+                    continue;
+                }
+
+                if (req.AllowedValues is { Count: > 0 })
+                {
+                    var match = req.AllowedValues
+                        .Any(v => string.Equals(v, tagValue, StringComparison.OrdinalIgnoreCase));
+                    if (!match)
+                    {
+                        violations.Add(new ComplianceViolation
+                        {
+                            PolicyName = policy.Name,
+                            TagName = req.Name,
+                            Reason = $"invalid value: {tagValue}"
+                        });
+                        continue;
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(req.Pattern))
+                {
+                    try
+                    {
+                        if (!Regex.IsMatch(tagValue, req.Pattern))
+                        {
+                            violations.Add(new ComplianceViolation
+                            {
+                                PolicyName = policy.Name,
+                                TagName = req.Name,
+                                Reason = $"pattern mismatch: {tagValue}"
+                            });
+                        }
+                    }
+                    catch (RegexParseException)
+                    {
+                        // Invalid regex in config — skip this check
+                    }
+                }
+            }
+        }
+
+        return violations;
+    }
+}

--- a/src/AzStamper.Core/StampOrchestrator.cs
+++ b/src/AzStamper.Core/StampOrchestrator.cs
@@ -13,6 +13,7 @@ public class StampOrchestrator
     private readonly StamperConfig _globalConfig;
     private readonly ConfigResolver _configResolver;
     private readonly ISubscriptionConfigProvider _subscriptionConfigProvider;
+    private readonly ComplianceEvaluator _complianceEvaluator;
     private readonly ILogger<StampOrchestrator> _logger;
 
     public StampOrchestrator(
@@ -21,6 +22,7 @@ public class StampOrchestrator
         IOptions<StamperConfig> globalConfig,
         ConfigResolver configResolver,
         ISubscriptionConfigProvider subscriptionConfigProvider,
+        ComplianceEvaluator complianceEvaluator,
         ILogger<StampOrchestrator> logger)
     {
         _callerResolver = callerResolver;
@@ -28,6 +30,7 @@ public class StampOrchestrator
         _globalConfig = globalConfig.Value;
         _configResolver = configResolver;
         _subscriptionConfigProvider = subscriptionConfigProvider;
+        _complianceEvaluator = complianceEvaluator;
         _logger = logger;
     }
 
@@ -171,6 +174,22 @@ public class StampOrchestrator
                 "Stamped {Count} tag(s) on {ResourceId} [Sub:{SubscriptionId}, Type:{ResourceType}, Config:{ConfigSource}] Tags:{AppliedTags}",
                 tagsToApply.Count, evt.ResourceId, subscriptionId, resourceType, ruleSet.ConfigSource,
                 JsonSerializer.Serialize(tagsToApply));
+
+            // Evaluate compliance policies after stamping
+            if (subConfig?.CompliancePolicies is { Count: > 0 })
+            {
+                var finalTags = new Dictionary<string, string>(existingTags);
+                foreach (var (k, v) in tagsToApply)
+                    finalTags[k] = v;
+
+                var violations = _complianceEvaluator.Evaluate(finalTags, subConfig.CompliancePolicies, resourceType);
+                foreach (var violation in violations)
+                {
+                    _logger.LogWarning(
+                        "Compliance violation on {ResourceId}: policy '{PolicyName}' — tag '{TagName}' {Reason} [Sub:{SubscriptionId}, Mode:audit]",
+                        evt.ResourceId, violation.PolicyName, violation.TagName, violation.Reason, subscriptionId);
+                }
+            }
         }
         else
         {

--- a/src/AzStamper.Functions/Program.cs
+++ b/src/AzStamper.Functions/Program.cs
@@ -71,6 +71,7 @@ else
             cacheTtl: TimeSpan.FromMinutes(5)));
 }
 
+builder.Services.AddSingleton<ComplianceEvaluator>();
 builder.Services.AddSingleton<StampOrchestrator>();
 
 builder.Build().Run();

--- a/stamper.schema.json
+++ b/stamper.schema.json
@@ -47,6 +47,13 @@
           "items": {
             "type": "string"
           }
+        },
+        "compliancePolicies": {
+          "type": "array",
+          "description": "Tag compliance policies for this subscription.",
+          "items": {
+            "$ref": "#/$defs/compliancePolicy"
+          }
         }
       }
     },
@@ -83,6 +90,64 @@
           }
         }
       }
+    },
+    "compliancePolicy": {
+      "type": "object",
+      "description": "Defines required tags and validation rules for compliance checking.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Display name for this policy."
+        },
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether this policy is active."
+        },
+        "requiredTags": {
+          "type": "array",
+          "description": "Tags that must exist on matching resources.",
+          "items": {
+            "$ref": "#/$defs/requiredTag"
+          }
+        },
+        "resourceTypeScope": {
+          "type": "array",
+          "description": "Resource types this policy applies to. Empty array means all types.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "enforcementMode": {
+          "type": "string",
+          "enum": ["audit"],
+          "default": "audit",
+          "description": "Enforcement mode. Currently only 'audit' (log violations without blocking)."
+        }
+      },
+      "required": ["name", "requiredTags"]
+    },
+    "requiredTag": {
+      "type": "object",
+      "description": "A tag that must exist on resources for compliance.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Tag name that must exist."
+        },
+        "allowedValues": {
+          "type": ["array", "null"],
+          "description": "Acceptable values. Null or omitted means any value is acceptable.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "pattern": {
+          "type": ["string", "null"],
+          "description": "Regex pattern the tag value must match."
+        }
+      },
+      "required": ["name"]
     }
   }
 }

--- a/swa/index.html
+++ b/swa/index.html
@@ -14,6 +14,7 @@
       <div class="tab active" data-tab="subscriptions">Configuration</div>
       <div class="tab" data-tab="simulate">Simulate</div>
       <div class="tab" data-tab="activity">Activity</div>
+      <div class="tab" data-tab="compliance">Compliance</div>
     </nav>
     <div class="header-user" id="user-info">
       <button class="btn btn-primary" id="sign-in-btn" data-action="sign-in">Sign In</button>
@@ -32,6 +33,7 @@
       <div class="tab-panel active" id="panel-subscriptions"></div>
       <div class="tab-panel" id="panel-simulate"></div>
       <div class="tab-panel" id="panel-activity"></div>
+      <div class="tab-panel" id="panel-compliance"></div>
     </div>
   </main>
 
@@ -47,6 +49,7 @@
   <script src="/js/tabs/subscriptions.js"></script>
   <script src="/js/tabs/simulate.js"></script>
   <script src="/js/tabs/activity.js"></script>
+  <script src="/js/tabs/compliance.js"></script>
   <script src="/js/app-init.js"></script>
 </body>
 </html>

--- a/swa/js/tabs/activity.js
+++ b/swa/js/tabs/activity.js
@@ -184,7 +184,7 @@ async function refreshActivity() {
     var kql = [
       'traces',
       '| where timestamp > ago(' + range + ')',
-      '| where message contains "Stamped" or message contains "skipping" or message contains "Failed"',
+      '| where message contains "Stamped" or message contains "skipping" or message contains "Failed" or message contains "Compliance violation"',
       '| extend ResourceId = coalesce(tostring(customDimensions.ResourceId), extract("(?:on|for) (/subscriptions/[^\\\\s\\\\[]+)", 1, message))',
       '| extend SubscriptionId = coalesce(tostring(customDimensions.SubscriptionId), extract("/subscriptions/([^/]+)", 1, ResourceId))',
       '| extend ResourceType = coalesce(tostring(customDimensions.ResourceType), extract("/providers/([^/]+/[^/]+)", 1, ResourceId))',
@@ -492,6 +492,12 @@ function parseAppliedTags(tagsStr) {
 }
 
 function classifyOutcome(message) {
+  if (message.indexOf('Compliance violation') !== -1) {
+    return {
+      label: 'Non-Compliant',
+      style: 'background:rgba(239,68,68,0.15);color:var(--error,#ef4444);',
+    };
+  }
   if (message.indexOf('Stamped') !== -1) {
     return {
       label: 'Tagged',

--- a/swa/js/tabs/compliance.js
+++ b/swa/js/tabs/compliance.js
@@ -1,0 +1,592 @@
+// Compliance Tab — scan resources via Resource Graph and evaluate tag compliance
+
+// Pagination state
+var COMP_PAGE_SIZE = 50;
+var _compCurrentPage = 0;
+var _compResults = null;
+
+// ── Entry point ──────────────────────────────────────────────────────────────
+
+async function loadComplianceTab() {
+  await discoverEnrollment();
+  var panel = document.getElementById('panel-compliance');
+  panel.textContent = '';
+  renderComplianceTab();
+}
+
+function renderComplianceTab() {
+  var panel = document.getElementById('panel-compliance');
+  panel.textContent = '';
+  _compResults = null;
+
+  var config = getConfig();
+  var configSubs = config.subscriptions || {};
+  var enrolledSubs = _enrollmentCache || [];
+  var subIds = enrolledSubs.map(function(s) { return s.subscriptionId; });
+  if (subIds.length === 0) subIds = Object.keys(configSubs);
+
+  var subDisplayNames = {};
+  enrolledSubs.forEach(function(s) { subDisplayNames[s.subscriptionId] = s.displayName; });
+  Object.keys(configSubs).forEach(function(id) {
+    if (!subDisplayNames[id]) subDisplayNames[id] = configSubs[id].displayName || '';
+  });
+
+  // ── Controls bar ──────────────────────────────────────────────────────────
+  var bar = document.createElement('div');
+  bar.className = 'controls-bar';
+  bar.style.flexWrap = 'wrap';
+  bar.style.gap = '10px';
+
+  var titleEl = document.createElement('span');
+  titleEl.className = 'controls-bar-title';
+  titleEl.textContent = 'Compliance';
+  bar.appendChild(titleEl);
+
+  // Subscription selector
+  var selectorWrapper = document.createElement('div');
+  selectorWrapper.style.cssText = 'display:flex;align-items:center;gap:8px;flex-shrink:0;';
+
+  var selectorLabel = document.createElement('label');
+  selectorLabel.setAttribute('for', 'comp-sub-selector');
+  selectorLabel.style.cssText = 'font-size:0.875rem;color:var(--text-secondary);white-space:nowrap;';
+  selectorLabel.textContent = 'Subscription:';
+
+  var selector = document.createElement('select');
+  selector.id = 'comp-sub-selector';
+  selector.className = 'form-select';
+  selector.style.cssText = 'min-width:220px;max-width:360px;';
+
+  var placeholderOpt = document.createElement('option');
+  placeholderOpt.value = '';
+  placeholderOpt.textContent = subIds.length === 0 ? '— no subscriptions —' : '— select a subscription —';
+  placeholderOpt.disabled = true;
+  placeholderOpt.selected = true;
+  selector.appendChild(placeholderOpt);
+
+  subIds.forEach(function(subId) {
+    var opt = document.createElement('option');
+    opt.value = subId;
+    var name = (subDisplayNames[subId] || '').trim();
+    opt.textContent = name ? name + ' (' + subId + ')' : subId;
+    selector.appendChild(opt);
+  });
+
+  selectorWrapper.appendChild(selectorLabel);
+  selectorWrapper.appendChild(selector);
+  bar.appendChild(selectorWrapper);
+
+  // Run Scan button
+  var runBtn = document.createElement('button');
+  runBtn.id = 'comp-run-btn';
+  runBtn.className = 'btn btn-primary';
+  runBtn.textContent = 'Run Scan';
+  runBtn.style.flexShrink = '0';
+  runBtn.addEventListener('click', function() {
+    var subId = selector.value;
+    if (!subId) {
+      showToast('Select a subscription first', 'error');
+      selector.focus();
+      return;
+    }
+    runComplianceScan(subId);
+  });
+  bar.appendChild(runBtn);
+
+  panel.appendChild(bar);
+
+  // ── Empty state ───────────────────────────────────────────────────────────
+  var resultsContainer = document.createElement('div');
+  resultsContainer.id = 'comp-results-container';
+  panel.appendChild(resultsContainer);
+
+  // Check if any subscription has compliance policies
+  var anyPolicies = subIds.some(function(id) {
+    var sub = configSubs[id];
+    return sub && sub.compliancePolicies && sub.compliancePolicies.length > 0;
+  });
+
+  var prompt = document.createElement('div');
+  prompt.className = 'empty-state';
+
+  if (!anyPolicies) {
+    var icon = document.createElement('div');
+    icon.className = 'empty-state-icon';
+    icon.textContent = '\uD83D\uDCCB';
+
+    var title = document.createElement('div');
+    title.className = 'empty-state-title';
+    title.textContent = 'No compliance policies configured';
+
+    var desc = document.createElement('div');
+    desc.className = 'empty-state-desc';
+    desc.textContent = 'Add compliance policies on the Configuration tab by clicking a subscription, then "+ Add Custom Config" and scrolling to the Compliance Policies section.';
+
+    prompt.appendChild(icon);
+    prompt.appendChild(title);
+    prompt.appendChild(desc);
+  } else {
+    var icon2 = document.createElement('div');
+    icon2.className = 'empty-state-icon';
+    icon2.textContent = '\u2705';
+
+    var title2 = document.createElement('div');
+    title2.className = 'empty-state-title';
+    title2.textContent = 'Ready to scan';
+
+    var desc2 = document.createElement('div');
+    desc2.className = 'empty-state-desc';
+    desc2.textContent = 'Select a subscription and click Run Scan to evaluate tag compliance across all resources.';
+
+    prompt.appendChild(icon2);
+    prompt.appendChild(title2);
+    prompt.appendChild(desc2);
+  }
+  resultsContainer.appendChild(prompt);
+}
+
+// ── Compliance scan ──────────────────────────────────────────────────────────
+
+async function runComplianceScan(subId) {
+  var runBtn = document.getElementById('comp-run-btn');
+  var resultsContainer = document.getElementById('comp-results-container');
+
+  if (runBtn) {
+    runBtn.disabled = true;
+    runBtn.textContent = 'Scanning\u2026';
+  }
+
+  resultsContainer.textContent = '';
+  var loading = document.createElement('div');
+  loading.className = 'loading-state';
+  var spinner = document.createElement('div');
+  spinner.className = 'spinner';
+  var loadingText = document.createElement('span');
+  loadingText.textContent = 'Querying Azure Resource Graph\u2026';
+  loading.appendChild(spinner);
+  loading.appendChild(loadingText);
+  resultsContainer.appendChild(loading);
+
+  try {
+    var token = await getManagementToken();
+    if (!token) {
+      showToast('Unable to acquire management token \u2014 please sign in', 'error');
+      return;
+    }
+
+    var config = getConfig();
+    var subConfig = (config.subscriptions || {})[subId] || {};
+    var policies = (subConfig.compliancePolicies || []).filter(function(p) { return p.enabled !== false; });
+
+    if (policies.length === 0) {
+      resultsContainer.textContent = '';
+      var noPolicy = document.createElement('div');
+      noPolicy.className = 'empty-state';
+      var npIcon = document.createElement('div');
+      npIcon.className = 'empty-state-icon';
+      npIcon.textContent = '\uD83D\uDCCB';
+      var npTitle = document.createElement('div');
+      npTitle.className = 'empty-state-title';
+      npTitle.textContent = 'No compliance policies for this subscription';
+      var npDesc = document.createElement('div');
+      npDesc.className = 'empty-state-desc';
+      npDesc.textContent = 'Add compliance policies on the Configuration tab to define which tags are required.';
+      noPolicy.appendChild(npIcon);
+      noPolicy.appendChild(npTitle);
+      noPolicy.appendChild(npDesc);
+      resultsContainer.appendChild(noPolicy);
+      return;
+    }
+
+    // Query Resource Graph
+    var kql = "Resources | where subscriptionId == '" + subId.replace(/'/g, '') + "' | project name, type, id, tags, resourceGroup | order by type asc, name asc | take 1000";
+    var url = 'https://management.azure.com/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01';
+    var result = await azureFetch(url, token, {
+      method: 'POST',
+      body: JSON.stringify({ query: kql, subscriptions: [subId] }),
+    });
+
+    var resources = (result && result.data) ? result.data : [];
+
+    // Evaluate each resource against policies
+    var compResults = resources.map(function(resource) {
+      return evaluateCompliance(resource, policies);
+    });
+
+    _compResults = compResults;
+    _compCurrentPage = 0;
+    renderComplianceResults(compResults, policies, resultsContainer);
+  } catch (err) {
+    console.error('Compliance scan error:', err);
+    showToast('Scan failed: ' + err.message, 'error');
+    resultsContainer.textContent = '';
+    var errorEl = document.createElement('div');
+    errorEl.style.cssText = 'padding:20px;border-radius:6px;background:var(--surface);border:1px solid var(--error, #ef4444);color:var(--error, #ef4444);font-size:0.875rem;margin-top:8px;';
+    errorEl.textContent = '\u26A0\uFE0F Scan failed: ' + err.message;
+    resultsContainer.appendChild(errorEl);
+  } finally {
+    if (runBtn) {
+      runBtn.disabled = false;
+      runBtn.textContent = 'Run Scan';
+    }
+  }
+}
+
+// ── Compliance evaluation ────────────────────────────────────────────────────
+
+function evaluateCompliance(resource, policies) {
+  var resourceType = (resource.type || '').toLowerCase();
+  var tags = resource.tags || {};
+  var violations = [];
+
+  policies.forEach(function(policy) {
+    // Check resourceTypeScope — empty means all types
+    if (policy.resourceTypeScope && policy.resourceTypeScope.length > 0) {
+      var inScope = policy.resourceTypeScope.some(function(scope) {
+        return scope.toLowerCase() === resourceType;
+      });
+      if (!inScope) return;
+    }
+
+    (policy.requiredTags || []).forEach(function(req) {
+      var tagValue = tags[req.name];
+
+      if (tagValue === undefined || tagValue === null) {
+        violations.push({ policy: policy.name, tag: req.name, reason: 'missing' });
+        return;
+      }
+
+      if (req.allowedValues && req.allowedValues.length > 0) {
+        var match = req.allowedValues.some(function(v) {
+          return v.toLowerCase() === String(tagValue).toLowerCase();
+        });
+        if (!match) {
+          violations.push({ policy: policy.name, tag: req.name, reason: 'invalid value: ' + tagValue });
+          return;
+        }
+      }
+
+      if (req.pattern) {
+        try {
+          var regex = new RegExp(req.pattern);
+          if (!regex.test(String(tagValue))) {
+            violations.push({ policy: policy.name, tag: req.name, reason: 'pattern mismatch: ' + tagValue });
+          }
+        } catch (e) {
+          // Invalid regex — skip this check
+        }
+      }
+    });
+  });
+
+  return {
+    name: resource.name || '',
+    type: resource.type || '',
+    resourceGroup: resource.resourceGroup || '',
+    id: resource.id || '',
+    tags: tags,
+    compliant: violations.length === 0,
+    violations: violations,
+  };
+}
+
+// ── Results rendering ────────────────────────────────────────────────────────
+
+function renderComplianceResults(results, policies, container) {
+  container.textContent = '';
+
+  var totalCount = results.length;
+  var compliantCount = results.filter(function(r) { return r.compliant; }).length;
+  var nonCompliantCount = totalCount - compliantCount;
+  var compliancePct = totalCount > 0 ? Math.round((compliantCount / totalCount) * 100) : 0;
+
+  // ── Summary bar ───────────────────────────────────────────────────────────
+  var summaryBar = document.createElement('div');
+  summaryBar.style.cssText = 'display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:10px;' +
+    'padding:12px 16px;margin-bottom:16px;background:var(--surface-secondary,var(--surface));' +
+    'border:1px solid var(--border);border-radius:6px;';
+
+  var summaryText = document.createElement('div');
+  summaryText.style.cssText = 'font-size:0.875rem;color:var(--text-secondary);display:flex;gap:16px;flex-wrap:wrap;align-items:center;';
+
+  function makeStat(value, label, color) {
+    var span = document.createElement('span');
+    var strong = document.createElement('strong');
+    strong.style.color = color || 'var(--text-primary)';
+    strong.textContent = String(value);
+    span.appendChild(strong);
+    span.appendChild(document.createTextNode(' ' + label));
+    return span;
+  }
+
+  summaryText.appendChild(makeStat(totalCount, 'resources scanned'));
+  summaryText.appendChild(document.createTextNode('\u00B7'));
+  summaryText.appendChild(makeStat(compliantCount, 'compliant', 'var(--success, #22c55e)'));
+  summaryText.appendChild(document.createTextNode('\u00B7'));
+  summaryText.appendChild(makeStat(nonCompliantCount, 'non-compliant', nonCompliantCount > 0 ? 'var(--error, #ef4444)' : 'var(--text-secondary)'));
+  summaryText.appendChild(document.createTextNode('\u00B7'));
+
+  // Compliance percentage badge
+  var pctBadge = document.createElement('span');
+  pctBadge.style.cssText = 'padding:2px 10px;border-radius:12px;font-weight:600;font-size:0.875rem;';
+  if (compliancePct >= 90) {
+    pctBadge.style.background = 'rgba(34,197,94,0.15)';
+    pctBadge.style.color = 'var(--success, #22c55e)';
+  } else if (compliancePct >= 60) {
+    pctBadge.style.background = 'rgba(234,179,8,0.15)';
+    pctBadge.style.color = 'var(--warning, #eab308)';
+  } else {
+    pctBadge.style.background = 'rgba(239,68,68,0.15)';
+    pctBadge.style.color = 'var(--error, #ef4444)';
+  }
+  pctBadge.textContent = compliancePct + '% compliant';
+  summaryText.appendChild(pctBadge);
+
+  summaryBar.appendChild(summaryText);
+
+  // Export buttons
+  if (totalCount > 0) {
+    var exportWrapper = document.createElement('div');
+    exportWrapper.style.cssText = 'display:flex;gap:8px;flex-shrink:0;';
+
+    var csvBtn = document.createElement('button');
+    csvBtn.className = 'btn btn-secondary btn-sm';
+    csvBtn.textContent = 'Export CSV';
+    csvBtn.addEventListener('click', function() { exportComplianceCsv(results); });
+
+    var jsonBtn = document.createElement('button');
+    jsonBtn.className = 'btn btn-secondary btn-sm';
+    jsonBtn.textContent = 'Export JSON';
+    jsonBtn.addEventListener('click', function() { exportComplianceJson(results); });
+
+    exportWrapper.appendChild(csvBtn);
+    exportWrapper.appendChild(jsonBtn);
+    summaryBar.appendChild(exportWrapper);
+  }
+
+  container.appendChild(summaryBar);
+
+  // ── Policy breakdown ──────────────────────────────────────────────────────
+  if (policies.length > 0 && nonCompliantCount > 0) {
+    var policyBreakdown = document.createElement('div');
+    policyBreakdown.style.cssText = 'display:flex;gap:12px;flex-wrap:wrap;margin-bottom:16px;';
+
+    policies.forEach(function(policy) {
+      var policyViolations = 0;
+      results.forEach(function(r) {
+        r.violations.forEach(function(v) {
+          if (v.policy === policy.name) policyViolations++;
+        });
+      });
+      if (policyViolations === 0) return;
+
+      var card = document.createElement('div');
+      card.style.cssText = 'padding:10px 16px;background:var(--surface);border:1px solid var(--border);border-radius:6px;font-size:0.8125rem;';
+
+      var pName = document.createElement('div');
+      pName.style.cssText = 'font-weight:600;color:var(--text-primary);margin-bottom:4px;';
+      pName.textContent = policy.name;
+
+      var pCount = document.createElement('div');
+      pCount.style.cssText = 'color:var(--error, #ef4444);';
+      pCount.textContent = policyViolations + ' violation' + (policyViolations !== 1 ? 's' : '');
+
+      card.appendChild(pName);
+      card.appendChild(pCount);
+      policyBreakdown.appendChild(card);
+    });
+
+    container.appendChild(policyBreakdown);
+  }
+
+  // ── Empty results ─────────────────────────────────────────────────────────
+  if (totalCount === 0) {
+    var empty = document.createElement('div');
+    empty.className = 'empty-state';
+    var emptyIcon = document.createElement('div');
+    emptyIcon.className = 'empty-state-icon';
+    emptyIcon.textContent = '\uD83D\uDCED';
+    var emptyTitle = document.createElement('div');
+    emptyTitle.className = 'empty-state-title';
+    emptyTitle.textContent = 'No resources found';
+    var emptyDesc = document.createElement('div');
+    emptyDesc.className = 'empty-state-desc';
+    emptyDesc.textContent = 'The query returned no resources for this subscription.';
+    empty.appendChild(emptyIcon);
+    empty.appendChild(emptyTitle);
+    empty.appendChild(emptyDesc);
+    container.appendChild(empty);
+    return;
+  }
+
+  // ── Pagination ────────────────────────────────────────────────────────────
+  var totalPages = Math.ceil(totalCount / COMP_PAGE_SIZE);
+  if (_compCurrentPage >= totalPages) _compCurrentPage = Math.max(0, totalPages - 1);
+  var pageStart = _compCurrentPage * COMP_PAGE_SIZE;
+  var pageEnd = Math.min(pageStart + COMP_PAGE_SIZE, totalCount);
+
+  // Sort: non-compliant first, then compliant
+  var sorted = results.slice().sort(function(a, b) {
+    if (a.compliant === b.compliant) return 0;
+    return a.compliant ? 1 : -1;
+  });
+  var pageResults = sorted.slice(pageStart, pageEnd);
+
+  // ── Results table ─────────────────────────────────────────────────────────
+  var tableWrapper = document.createElement('div');
+  tableWrapper.style.cssText = 'overflow-x:auto;';
+
+  var table = document.createElement('table');
+  table.style.cssText = 'width:100%;border-collapse:collapse;font-size:0.8125rem;';
+
+  var thead = document.createElement('thead');
+  var headerRow = document.createElement('tr');
+  ['Resource Name', 'Type', 'Resource Group', 'Status', 'Violations'].forEach(function(col) {
+    var th = document.createElement('th');
+    th.style.cssText = 'padding:8px 12px;text-align:left;font-weight:600;font-size:0.75rem;' +
+      'text-transform:uppercase;letter-spacing:0.05em;color:var(--text-secondary);' +
+      'border-bottom:2px solid var(--border);white-space:nowrap;';
+    th.textContent = col;
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  var tbody = document.createElement('tbody');
+  pageResults.forEach(function(result, index) {
+    var tr = document.createElement('tr');
+    tr.style.cssText = 'border-bottom:1px solid var(--border);';
+    if (index % 2 === 1) tr.style.backgroundColor = 'var(--surface-secondary, rgba(0,0,0,0.02))';
+
+    // Name
+    var tdName = document.createElement('td');
+    tdName.style.cssText = 'padding:8px 12px;font-weight:500;vertical-align:top;max-width:200px;word-break:break-all;';
+    tdName.textContent = result.name;
+
+    // Type
+    var tdType = document.createElement('td');
+    tdType.style.cssText = 'padding:8px 12px;font-family:monospace;font-size:0.75rem;color:var(--text-secondary);vertical-align:top;max-width:240px;word-break:break-all;';
+    tdType.textContent = result.type;
+
+    // Resource Group
+    var tdRg = document.createElement('td');
+    tdRg.style.cssText = 'padding:8px 12px;font-size:0.8125rem;color:var(--text-secondary);vertical-align:top;';
+    tdRg.textContent = result.resourceGroup;
+
+    // Status
+    var tdStatus = document.createElement('td');
+    tdStatus.style.cssText = 'padding:8px 12px;vertical-align:top;white-space:nowrap;';
+    var statusBadge = document.createElement('span');
+    statusBadge.className = 'badge';
+    if (result.compliant) {
+      statusBadge.className += ' badge-enabled';
+      statusBadge.textContent = 'Compliant';
+    } else {
+      statusBadge.style.cssText = 'display:inline-block;padding:2px 8px;border-radius:4px;font-size:0.75rem;font-weight:600;background:rgba(239,68,68,0.15);color:var(--error, #ef4444);';
+      statusBadge.textContent = 'Non-Compliant';
+    }
+    tdStatus.appendChild(statusBadge);
+
+    // Violations
+    var tdViolations = document.createElement('td');
+    tdViolations.style.cssText = 'padding:8px 12px;vertical-align:top;';
+    if (result.violations.length > 0) {
+      result.violations.forEach(function(v) {
+        var chip = document.createElement('span');
+        chip.style.cssText = 'display:inline-block;margin:2px 4px 2px 0;padding:2px 8px;border-radius:4px;font-size:0.75rem;background:rgba(239,68,68,0.1);color:var(--error, #ef4444);';
+        chip.textContent = v.tag + ' (' + v.reason + ')';
+        tdViolations.appendChild(chip);
+      });
+    } else {
+      var ok = document.createElement('span');
+      ok.style.cssText = 'font-size:0.75rem;color:var(--text-muted);font-style:italic;';
+      ok.textContent = 'none';
+      tdViolations.appendChild(ok);
+    }
+
+    tr.appendChild(tdName);
+    tr.appendChild(tdType);
+    tr.appendChild(tdRg);
+    tr.appendChild(tdStatus);
+    tr.appendChild(tdViolations);
+    tbody.appendChild(tr);
+  });
+
+  table.appendChild(tbody);
+  tableWrapper.appendChild(table);
+  container.appendChild(tableWrapper);
+
+  // Pagination controls
+  if (totalPages > 1) {
+    var paginationBar = document.createElement('div');
+    paginationBar.style.cssText = 'display:flex;align-items:center;justify-content:center;gap:12px;padding:14px 0;';
+
+    var prevBtn = document.createElement('button');
+    prevBtn.className = 'btn btn-secondary btn-sm';
+    prevBtn.textContent = '\u2190 Prev';
+    prevBtn.disabled = _compCurrentPage === 0;
+    prevBtn.addEventListener('click', function() {
+      _compCurrentPage--;
+      renderComplianceResults(sorted, policies, container);
+    });
+
+    var pageInfo = document.createElement('span');
+    pageInfo.style.cssText = 'font-size:0.8125rem;color:var(--text-secondary);';
+    pageInfo.textContent = (pageStart + 1) + '\u2013' + pageEnd + ' of ' + totalCount;
+
+    var nextBtn = document.createElement('button');
+    nextBtn.className = 'btn btn-secondary btn-sm';
+    nextBtn.textContent = 'Next \u2192';
+    nextBtn.disabled = _compCurrentPage >= totalPages - 1;
+    nextBtn.addEventListener('click', function() {
+      _compCurrentPage++;
+      renderComplianceResults(sorted, policies, container);
+    });
+
+    paginationBar.appendChild(prevBtn);
+    paginationBar.appendChild(pageInfo);
+    paginationBar.appendChild(nextBtn);
+    container.appendChild(paginationBar);
+  }
+}
+
+// ── Export ────────────────────────────────────────────────────────────────────
+
+function exportComplianceCsv(results) {
+  var rows = [['Resource', 'Type', 'ResourceGroup', 'Status', 'Violations']];
+  results.forEach(function(r) {
+    var violationStr = r.violations.map(function(v) { return v.tag + ':' + v.reason; }).join('; ');
+    rows.push([r.name, r.type, r.resourceGroup, r.compliant ? 'Compliant' : 'Non-Compliant', violationStr]);
+  });
+
+  var csvContent = rows.map(function(row) {
+    return row.map(function(cell) {
+      var str = String(cell == null ? '' : cell);
+      if (str.indexOf(',') !== -1 || str.indexOf('"') !== -1 || str.indexOf('\n') !== -1) {
+        return '"' + str.replace(/"/g, '""') + '"';
+      }
+      return str;
+    }).join(',');
+  }).join('\r\n');
+
+  downloadBlob(csvContent, 'text/csv;charset=utf-8;', 'az-stamper-compliance.csv');
+  showToast('Compliance report exported as CSV', 'success');
+}
+
+function exportComplianceJson(results) {
+  var report = results.map(function(r) {
+    return {
+      resource: r.name,
+      type: r.type,
+      resourceGroup: r.resourceGroup,
+      resourceId: r.id,
+      compliant: r.compliant,
+      violations: r.violations,
+      tags: r.tags,
+    };
+  });
+  downloadBlob(JSON.stringify(report, null, 2), 'application/json', 'az-stamper-compliance.json');
+  showToast('Compliance report exported as JSON', 'success');
+}
+
+// Expose entry point
+window.loadComplianceTab = loadComplianceTab;

--- a/swa/js/tabs/subscriptions.js
+++ b/swa/js/tabs/subscriptions.js
@@ -648,6 +648,26 @@ function buildInlineEditor(sub) {
   });
   ignoreSubsection.appendChild(addPatternBtn);
 
+  // Compliance Policies
+  var complianceSubsection = buildSubsection('Compliance Policies', overridesBody);
+  var policyList = document.createElement('div');
+  policyList.className = 'compliance-policy-list';
+  complianceSubsection.appendChild(policyList);
+
+  var existingPolicies = subConfig.compliancePolicies || [];
+  existingPolicies.forEach(function(policy) {
+    policyList.appendChild(buildCompliancePolicyRow(policy));
+  });
+
+  var addPolicyBtn = document.createElement('button');
+  addPolicyBtn.className = 'btn btn-secondary btn-sm';
+  addPolicyBtn.style.cssText = 'margin:10px 20px 14px;';
+  addPolicyBtn.textContent = '+ Add Policy';
+  addPolicyBtn.addEventListener('click', function() {
+    policyList.appendChild(buildCompliancePolicyRow({ name: '', enabled: true, requiredTags: [{ name: '' }], resourceTypeScope: [], enforcementMode: 'audit' }));
+  });
+  complianceSubsection.appendChild(addPolicyBtn);
+
   // ── Save / Reset action bar ─────────────────────────────────────────────
   var actionBar = document.createElement('div');
   actionBar.style.cssText = 'display:flex;gap:10px;justify-content:flex-end;margin-top:16px;';
@@ -1222,6 +1242,106 @@ function buildIgnorePatternRow(pattern) {
   return row;
 }
 
+function buildCompliancePolicyRow(policy) {
+  var row = document.createElement('div');
+  row.className = 'compliance-policy-row';
+  row.style.cssText = 'padding:12px 16px;margin:8px 0;background:var(--surface);border:1px solid var(--border);border-radius:6px;';
+
+  // Header: name + enabled + remove
+  var header = document.createElement('div');
+  header.style.cssText = 'display:flex;gap:10px;align-items:center;margin-bottom:10px;';
+
+  var nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.className = 'form-input compliance-policy-name';
+  nameInput.style.cssText = 'flex:1;font-weight:600;';
+  nameInput.placeholder = 'Policy name (e.g. Mandatory Tags)';
+  nameInput.value = policy.name || '';
+
+  var enabledLabel = document.createElement('label');
+  enabledLabel.style.cssText = 'display:flex;align-items:center;gap:4px;font-size:0.8125rem;color:var(--text-secondary);cursor:pointer;white-space:nowrap;';
+  var enabledCheckbox = document.createElement('input');
+  enabledCheckbox.type = 'checkbox';
+  enabledCheckbox.className = 'compliance-policy-enabled';
+  enabledCheckbox.checked = policy.enabled !== false;
+  enabledLabel.appendChild(enabledCheckbox);
+  enabledLabel.appendChild(document.createTextNode('Enabled'));
+
+  var removeBtn = document.createElement('button');
+  removeBtn.className = 'btn btn-danger btn-sm';
+  removeBtn.textContent = 'Remove';
+  removeBtn.addEventListener('click', function() { row.remove(); });
+
+  header.appendChild(nameInput);
+  header.appendChild(enabledLabel);
+  header.appendChild(removeBtn);
+  row.appendChild(header);
+
+  // Required tags list
+  var tagsLabel = document.createElement('div');
+  tagsLabel.style.cssText = 'font-size:0.75rem;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;color:var(--text-secondary);margin-bottom:6px;';
+  tagsLabel.textContent = 'Required Tags';
+  row.appendChild(tagsLabel);
+
+  var tagsList = document.createElement('div');
+  tagsList.className = 'compliance-required-tags';
+  row.appendChild(tagsList);
+
+  (policy.requiredTags || []).forEach(function(rt) {
+    tagsList.appendChild(buildRequiredTagRow(rt));
+  });
+
+  var addTagBtn = document.createElement('button');
+  addTagBtn.className = 'btn btn-secondary btn-sm';
+  addTagBtn.style.cssText = 'margin-top:6px;';
+  addTagBtn.textContent = '+ Required Tag';
+  addTagBtn.addEventListener('click', function() {
+    tagsList.appendChild(buildRequiredTagRow({ name: '' }));
+  });
+  row.appendChild(addTagBtn);
+
+  return row;
+}
+
+function buildRequiredTagRow(rt) {
+  var row = document.createElement('div');
+  row.className = 'compliance-required-tag-row';
+  row.style.cssText = 'display:flex;gap:8px;align-items:center;margin-bottom:6px;flex-wrap:wrap;';
+
+  var nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.className = 'form-input compliance-tag-name';
+  nameInput.style.cssText = 'width:160px;';
+  nameInput.placeholder = 'Tag name';
+  nameInput.value = rt.name || '';
+
+  var valuesInput = document.createElement('input');
+  valuesInput.type = 'text';
+  valuesInput.className = 'form-input compliance-tag-values';
+  valuesInput.style.cssText = 'flex:1;min-width:180px;';
+  valuesInput.placeholder = 'Allowed values (comma-separated, optional)';
+  valuesInput.value = (rt.allowedValues || []).join(', ');
+
+  var patternInput = document.createElement('input');
+  patternInput.type = 'text';
+  patternInput.className = 'form-input compliance-tag-pattern';
+  patternInput.style.cssText = 'width:160px;font-family:monospace;font-size:0.8125rem;';
+  patternInput.placeholder = 'Regex (optional)';
+  patternInput.value = rt.pattern || '';
+
+  var removeBtn = document.createElement('button');
+  removeBtn.className = 'btn btn-danger btn-sm';
+  removeBtn.textContent = 'Remove';
+  removeBtn.addEventListener('click', function() { row.remove(); });
+
+  row.appendChild(nameInput);
+  row.appendChild(valuesInput);
+  row.appendChild(patternInput);
+  row.appendChild(removeBtn);
+
+  return row;
+}
+
 // ── Save Inline Editor ──────────────────────────────────────────────────────
 
 async function saveInlineEditor(subId, editorEl, saveBtn) {
@@ -1325,11 +1445,49 @@ async function saveInlineEditor(subId, editorEl, saveBtn) {
     if (pattern) additionalIgnorePatterns.push(pattern);
   });
 
+  // Collect compliance policies
+  var compliancePolicies = [];
+  var policyRows = editorEl.querySelectorAll('.compliance-policy-list .compliance-policy-row');
+  policyRows.forEach(function(policyRow) {
+    var nameInput = policyRow.querySelector('.compliance-policy-name');
+    var policyName = (nameInput ? nameInput.value : '').trim();
+    if (!policyName) return;
+
+    var enabledCheckbox = policyRow.querySelector('.compliance-policy-enabled');
+    var enabled = enabledCheckbox ? enabledCheckbox.checked : true;
+
+    var requiredTags = [];
+    var tagRows = policyRow.querySelectorAll('.compliance-required-tag-row');
+    tagRows.forEach(function(tagRow) {
+      var tagNameInput = tagRow.querySelector('.compliance-tag-name');
+      var tagName = (tagNameInput ? tagNameInput.value : '').trim();
+      if (!tagName) return;
+
+      var valuesInput = tagRow.querySelector('.compliance-tag-values');
+      var valuesStr = (valuesInput ? valuesInput.value : '').trim();
+      var allowedValues = valuesStr ? valuesStr.split(',').map(function(v) { return v.trim(); }).filter(Boolean) : null;
+
+      var patternInput = tagRow.querySelector('.compliance-tag-pattern');
+      var pattern = (patternInput ? patternInput.value : '').trim() || null;
+
+      requiredTags.push({ name: tagName, allowedValues: allowedValues, pattern: pattern });
+    });
+
+    compliancePolicies.push({
+      name: policyName,
+      enabled: enabled,
+      requiredTags: requiredTags,
+      resourceTypeScope: [],
+      enforcementMode: 'audit',
+    });
+  });
+
   // Build updated subscription config
   var updatedSub = Object.assign({}, config.subscriptions[subId], {
     tagOverrides: tagOverrides,
     resourceTypeRules: resourceTypeRules,
     additionalIgnorePatterns: additionalIgnorePatterns,
+    compliancePolicies: compliancePolicies,
   });
 
   config.subscriptions[subId] = updatedSub;

--- a/tests/AzStamper.Core.Tests/ComplianceEvaluatorTests.cs
+++ b/tests/AzStamper.Core.Tests/ComplianceEvaluatorTests.cs
@@ -1,0 +1,181 @@
+using AzStamper.Core.Models;
+using AzStamper.Core.Services;
+
+namespace AzStamper.Core.Tests;
+
+public class ComplianceEvaluatorTests
+{
+    private readonly ComplianceEvaluator _evaluator = new();
+
+    [Fact]
+    public void NoPolicies_ReturnsNoViolations()
+    {
+        var tags = new Dictionary<string, string> { ["Creator"] = "alice" };
+        var result = _evaluator.Evaluate(tags, new List<CompliancePolicy>(), "Microsoft.Compute/virtualMachines");
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void DisabledPolicy_IsSkipped()
+    {
+        var tags = new Dictionary<string, string>();
+        var policies = new List<CompliancePolicy>
+        {
+            new() { Name = "Test", Enabled = false, RequiredTags = new() { new() { Name = "Creator" } } }
+        };
+        var result = _evaluator.Evaluate(tags, policies, "Microsoft.Compute/virtualMachines");
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void MissingRequiredTag_ProducesViolation()
+    {
+        var tags = new Dictionary<string, string> { ["Environment"] = "Dev" };
+        var policies = new List<CompliancePolicy>
+        {
+            new() { Name = "Mandatory", RequiredTags = new() { new() { Name = "Creator" }, new() { Name = "Environment" } } }
+        };
+        var result = _evaluator.Evaluate(tags, policies, "Microsoft.Compute/virtualMachines");
+        Assert.Single(result);
+        Assert.Equal("Creator", result[0].TagName);
+        Assert.Equal("missing", result[0].Reason);
+        Assert.Equal("Mandatory", result[0].PolicyName);
+    }
+
+    [Fact]
+    public void TagPresentWithCorrectValue_Passes()
+    {
+        var tags = new Dictionary<string, string> { ["Environment"] = "Production" };
+        var policies = new List<CompliancePolicy>
+        {
+            new()
+            {
+                Name = "Env Check",
+                RequiredTags = new() { new() { Name = "Environment", AllowedValues = new() { "Production", "Dev" } } }
+            }
+        };
+        var result = _evaluator.Evaluate(tags, policies, "Microsoft.Compute/virtualMachines");
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void TagPresentWithWrongValue_ProducesViolation()
+    {
+        var tags = new Dictionary<string, string> { ["Environment"] = "Staging" };
+        var policies = new List<CompliancePolicy>
+        {
+            new()
+            {
+                Name = "Env Check",
+                RequiredTags = new() { new() { Name = "Environment", AllowedValues = new() { "Production", "Dev" } } }
+            }
+        };
+        var result = _evaluator.Evaluate(tags, policies, "Microsoft.Compute/virtualMachines");
+        Assert.Single(result);
+        Assert.Contains("invalid value", result[0].Reason);
+    }
+
+    [Fact]
+    public void PatternMatch_Passes()
+    {
+        var tags = new Dictionary<string, string> { ["CostCenter"] = "CC-1234" };
+        var policies = new List<CompliancePolicy>
+        {
+            new()
+            {
+                Name = "Cost",
+                RequiredTags = new() { new() { Name = "CostCenter", Pattern = @"^CC-\d{4}$" } }
+            }
+        };
+        var result = _evaluator.Evaluate(tags, policies, "Microsoft.Compute/virtualMachines");
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void PatternMismatch_ProducesViolation()
+    {
+        var tags = new Dictionary<string, string> { ["CostCenter"] = "INVALID" };
+        var policies = new List<CompliancePolicy>
+        {
+            new()
+            {
+                Name = "Cost",
+                RequiredTags = new() { new() { Name = "CostCenter", Pattern = @"^CC-\d{4}$" } }
+            }
+        };
+        var result = _evaluator.Evaluate(tags, policies, "Microsoft.Compute/virtualMachines");
+        Assert.Single(result);
+        Assert.Contains("pattern mismatch", result[0].Reason);
+    }
+
+    [Fact]
+    public void ResourceTypeScope_FiltersCorrectly()
+    {
+        var tags = new Dictionary<string, string>();
+        var policies = new List<CompliancePolicy>
+        {
+            new()
+            {
+                Name = "VM Only",
+                RequiredTags = new() { new() { Name = "Creator" } },
+                ResourceTypeScope = new() { "Microsoft.Compute/virtualMachines" }
+            }
+        };
+
+        // Resource type matches scope — should produce violation
+        var result1 = _evaluator.Evaluate(tags, policies, "Microsoft.Compute/virtualMachines");
+        Assert.Single(result1);
+
+        // Resource type outside scope — should skip
+        var result2 = _evaluator.Evaluate(tags, policies, "Microsoft.Storage/storageAccounts");
+        Assert.Empty(result2);
+    }
+
+    [Fact]
+    public void NullAllowedValues_AcceptsAnyValue()
+    {
+        var tags = new Dictionary<string, string> { ["Creator"] = "literally-anything" };
+        var policies = new List<CompliancePolicy>
+        {
+            new()
+            {
+                Name = "Exists Check",
+                RequiredTags = new() { new() { Name = "Creator", AllowedValues = null } }
+            }
+        };
+        var result = _evaluator.Evaluate(tags, policies, "Microsoft.Compute/virtualMachines");
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AllowedValues_CaseInsensitive()
+    {
+        var tags = new Dictionary<string, string> { ["Environment"] = "production" };
+        var policies = new List<CompliancePolicy>
+        {
+            new()
+            {
+                Name = "Env",
+                RequiredTags = new() { new() { Name = "Environment", AllowedValues = new() { "Production" } } }
+            }
+        };
+        var result = _evaluator.Evaluate(tags, policies, "Microsoft.Compute/virtualMachines");
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void InvalidRegex_DoesNotThrow()
+    {
+        var tags = new Dictionary<string, string> { ["Tag"] = "value" };
+        var policies = new List<CompliancePolicy>
+        {
+            new()
+            {
+                Name = "Bad Regex",
+                RequiredTags = new() { new() { Name = "Tag", Pattern = "[invalid(" } }
+            }
+        };
+        var result = _evaluator.Evaluate(tags, policies, "Microsoft.Compute/virtualMachines");
+        Assert.Empty(result); // Invalid regex is silently skipped
+    }
+}

--- a/tests/AzStamper.Core.Tests/CompliancePolicyTests.cs
+++ b/tests/AzStamper.Core.Tests/CompliancePolicyTests.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+using AzStamper.Core.Models;
+
+namespace AzStamper.Core.Tests;
+
+public class CompliancePolicyTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    [Fact]
+    public void OldJson_WithoutCompliancePolicies_DeserializesCleanly()
+    {
+        var json = """
+        {
+          "subscriptions": {
+            "sub-1": {
+              "displayName": "Test",
+              "enabled": true,
+              "tagOverrides": { "Env": { "value": "Dev", "overwrite": false } }
+            }
+          }
+        }
+        """;
+
+        var root = JsonSerializer.Deserialize<SubscriptionConfigRoot>(json, JsonOptions)!;
+        var sub = root.Subscriptions["sub-1"];
+
+        Assert.Empty(sub.CompliancePolicies);
+        Assert.Equal("Test", sub.DisplayName);
+        Assert.Single(sub.TagOverrides);
+    }
+
+    [Fact]
+    public void Json_WithCompliancePolicies_RoundTrips()
+    {
+        var root = new SubscriptionConfigRoot
+        {
+            Subscriptions = new Dictionary<string, SubscriptionConfig>
+            {
+                ["sub-1"] = new()
+                {
+                    DisplayName = "Production",
+                    CompliancePolicies = new List<CompliancePolicy>
+                    {
+                        new()
+                        {
+                            Name = "Mandatory Tags",
+                            Enabled = true,
+                            EnforcementMode = "audit",
+                            RequiredTags = new List<RequiredTag>
+                            {
+                                new() { Name = "Creator" },
+                                new() { Name = "Environment", AllowedValues = new() { "Production", "Dev" } },
+                                new() { Name = "CostCenter", Pattern = @"^CC-\d{4}$" }
+                            },
+                            ResourceTypeScope = new List<string> { "Microsoft.Compute/virtualMachines" }
+                        }
+                    }
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(root, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<SubscriptionConfigRoot>(json, JsonOptions)!;
+
+        var policy = deserialized.Subscriptions["sub-1"].CompliancePolicies[0];
+        Assert.Equal("Mandatory Tags", policy.Name);
+        Assert.True(policy.Enabled);
+        Assert.Equal("audit", policy.EnforcementMode);
+        Assert.Equal(3, policy.RequiredTags.Count);
+
+        Assert.Equal("Creator", policy.RequiredTags[0].Name);
+        Assert.Null(policy.RequiredTags[0].AllowedValues);
+
+        Assert.Equal("Environment", policy.RequiredTags[1].Name);
+        Assert.Equal(new[] { "Production", "Dev" }, policy.RequiredTags[1].AllowedValues);
+
+        Assert.Equal("CostCenter", policy.RequiredTags[2].Name);
+        Assert.Equal(@"^CC-\d{4}$", policy.RequiredTags[2].Pattern);
+
+        Assert.Single(policy.ResourceTypeScope);
+        Assert.Equal("Microsoft.Compute/virtualMachines", policy.ResourceTypeScope[0]);
+    }
+
+    [Fact]
+    public void DefaultCompliancePolicy_HasCorrectDefaults()
+    {
+        var policy = new CompliancePolicy();
+
+        Assert.Equal("Default", policy.Name);
+        Assert.True(policy.Enabled);
+        Assert.Equal("audit", policy.EnforcementMode);
+        Assert.Empty(policy.RequiredTags);
+        Assert.Empty(policy.ResourceTypeScope);
+    }
+
+    [Fact]
+    public void RequiredTag_AllowsNullOptionalFields()
+    {
+        var tag = new RequiredTag { Name = "Creator" };
+
+        Assert.Equal("Creator", tag.Name);
+        Assert.Null(tag.AllowedValues);
+        Assert.Null(tag.Pattern);
+    }
+}

--- a/tests/AzStamper.Core.Tests/StampOrchestratorMultiSubTests.cs
+++ b/tests/AzStamper.Core.Tests/StampOrchestratorMultiSubTests.cs
@@ -35,6 +35,7 @@ public class StampOrchestratorMultiSubTests
             Options.Create(GlobalConfig),
             configResolver,
             _configProvider.Object,
+            new Services.ComplianceEvaluator(),
             _logger.Object);
     }
 

--- a/tests/AzStamper.Core.Tests/StampOrchestratorTests.cs
+++ b/tests/AzStamper.Core.Tests/StampOrchestratorTests.cs
@@ -47,6 +47,7 @@ public class StampOrchestratorTests
             options,
             configResolver,
             _configProvider.Object,
+            new Services.ComplianceEvaluator(),
             _logger.Object);
     }
 


### PR DESCRIPTION
## Summary
- **Tag compliance dashboard** (#118): New Compliance tab that scans resources via Azure Resource Graph and evaluates them against compliance policies (required tags, allowed values, regex patterns). Includes summary stats, sortable results table, policy violation breakdown, and CSV/JSON export
- **Policy enforcement** (#119): `ComplianceEvaluator` service evaluates tags after stamping and logs violations to App Insights (audit-only mode). Activity tab shows "Non-Compliant" badges for violation events
- **Compliance policy editor**: Configuration tab gets a new section for adding/editing compliance policies with required tags, allowed values, and regex patterns — persisted to `stamper.json`
- **Data model**: `CompliancePolicy` + `RequiredTag` models, backward-compatible schema extension

## Test plan
- [x] 62 unit tests pass (11 new ComplianceEvaluator + 4 CompliancePolicy + 47 existing)
- [ ] Compliance tab shows empty state when no policies configured
- [ ] Add policy via Configuration tab, save, verify persistence
- [ ] Run compliance scan on enrolled subscription, verify results
- [ ] Export compliance report as CSV and JSON
- [ ] Deploy function app, trigger resource creation, verify compliance violation traces in App Insights
- [ ] Activity tab shows Non-Compliant badge for violation events
- [ ] Backward compat: old stamper.json without compliancePolicies works correctly

Closes #118, #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)