### PR TITLE
fix: break self-trigger feedback loop in StampOrchestrator

### DIFF
--- a/src/AzStamper.Core/Models/StamperConfig.cs
+++ b/src/AzStamper.Core/Models/StamperConfig.cs
@@ -5,4 +5,5 @@ public class StamperConfig
     public Dictionary<string, TagEntry> TagMap { get; set; } = new();
     public List<string> IgnorePatterns { get; set; } = new();
     public string? SelfPrincipalId { get; set; }
+    public string? SelfAppName { get; set; }
 }

--- a/src/AzStamper.Core/StampOrchestrator.cs
+++ b/src/AzStamper.Core/StampOrchestrator.cs
@@ -102,6 +102,16 @@ public class StampOrchestrator
             }
         }
 
+        // Secondary self-trigger check: compare resolved caller name against our own app name
+        if (!string.IsNullOrEmpty(_globalConfig.SelfAppName) &&
+            string.Equals(caller, _globalConfig.SelfAppName, StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogInformation(
+                "Skipping self-triggered event for {ResourceId} — caller '{Caller}' matches self app name",
+                evt.ResourceId, caller);
+            return;
+        }
+
         _logger.LogInformation("Processing {ResourceId} — caller: {Caller}, config: {ConfigSource}",
             evt.ResourceId, caller, ruleSet.ConfigSource);
 
@@ -149,6 +159,15 @@ public class StampOrchestrator
                 _logger.LogWarning("Tag '{Key}' value exceeds 256 chars ({Length}) — truncating", key, value.Length);
                 value = value[..256];
             }
+
+            // Skip if existing tag already has the same value (prevents no-op ARM writes that trigger events)
+            if (existingTags.TryGetValue(key, out var existingValue) &&
+                string.Equals(existingValue, value, StringComparison.Ordinal))
+            {
+                _logger.LogDebug("Tag '{Key}' unchanged on {ResourceId} — skipping", key, evt.ResourceId);
+                continue;
+            }
+
             tagsToApply[key] = value;
         }
 

--- a/src/AzStamper.Functions/Program.cs
+++ b/src/AzStamper.Functions/Program.cs
@@ -35,6 +35,14 @@ builder.Logging.Services.Configure<LoggerFilterOptions>(options =>
 builder.Services.Configure<StamperConfig>(
     builder.Configuration.GetSection("StamperConfig"));
 
+builder.Services.PostConfigure<StamperConfig>(config =>
+{
+    if (string.IsNullOrEmpty(config.SelfAppName))
+    {
+        config.SelfAppName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
+    }
+});
+
 var credential = new DefaultAzureCredential();
 
 builder.Services.AddSingleton(new ArmClient(credential));

--- a/tests/AzStamper.Core.Tests/StampOrchestratorTests.cs
+++ b/tests/AzStamper.Core.Tests/StampOrchestratorTests.cs
@@ -474,4 +474,174 @@ public class StampOrchestratorTests
         _tagService.Verify(x => x.SetTagsAsync(
             It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()), Times.Never);
     }
+
+    [Fact]
+    public async Task SkipsSelfTriggeredEvent_BySelfAppName()
+    {
+        var resourceId = "/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1";
+        _callerResolver
+            .Setup(x => x.ResolveDisplayNameAsync("sp-id-func", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("func-azstamper-pcxd");
+
+        var config = new StamperConfig
+        {
+            TagMap = new Dictionary<string, TagEntry>
+            {
+                ["Creator"] = new() { Value = "{caller}", Overwrite = false }
+            },
+            IgnorePatterns = new List<string>(),
+            SelfAppName = "func-azstamper-pcxd"
+        };
+
+        var orchestrator = CreateOrchestrator(config);
+        var evt = new ResourceEvent
+        {
+            ResourceId = resourceId,
+            Caller = null,
+            PrincipalType = "ServicePrincipal",
+            PrincipalId = "sp-id-func"
+        };
+
+        await orchestrator.ProcessAsync(evt);
+
+        _tagService.Verify(x => x.SetTagsAsync(
+            It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SelfAppNameCheck_IsCaseInsensitive()
+    {
+        var resourceId = "/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1";
+        _callerResolver
+            .Setup(x => x.ResolveDisplayNameAsync("sp-id-func", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("Func-AzStamper-Pcxd");
+
+        var config = new StamperConfig
+        {
+            TagMap = new Dictionary<string, TagEntry>
+            {
+                ["Creator"] = new() { Value = "{caller}", Overwrite = false }
+            },
+            IgnorePatterns = new List<string>(),
+            SelfAppName = "func-azstamper-pcxd"
+        };
+
+        var orchestrator = CreateOrchestrator(config);
+        var evt = new ResourceEvent
+        {
+            ResourceId = resourceId,
+            Caller = null,
+            PrincipalType = "ServicePrincipal",
+            PrincipalId = "sp-id-func"
+        };
+
+        await orchestrator.ProcessAsync(evt);
+
+        _tagService.Verify(x => x.SetTagsAsync(
+            It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SelfAppNameCheck_SkippedWhenNotConfigured()
+    {
+        var resourceId = "/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1";
+        _callerResolver
+            .Setup(x => x.ResolveDisplayNameAsync("sp-id-other", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("other-service");
+        _tagService
+            .Setup(x => x.GetTagsAsync(resourceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string>());
+        _tagService
+            .Setup(x => x.SetTagsAsync(resourceId, It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var config = new StamperConfig
+        {
+            TagMap = new Dictionary<string, TagEntry>
+            {
+                ["Creator"] = new() { Value = "{caller}", Overwrite = false }
+            },
+            IgnorePatterns = new List<string>(),
+            SelfAppName = null
+        };
+
+        var orchestrator = CreateOrchestrator(config);
+        var evt = new ResourceEvent
+        {
+            ResourceId = resourceId,
+            Caller = null,
+            PrincipalType = "ServicePrincipal",
+            PrincipalId = "sp-id-other"
+        };
+
+        await orchestrator.ProcessAsync(evt);
+
+        _tagService.Verify(x => x.SetTagsAsync(
+            resourceId, It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SkipsOverwriteTag_WhenValueUnchanged()
+    {
+        var resourceId = "/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1";
+        _tagService
+            .Setup(x => x.GetTagsAsync(resourceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string>
+            {
+                ["Creator"] = "alice@contoso.com",
+                ["CreatedOn"] = "2026-01-01T00:00:00Z",
+                ["StampedBy"] = "Az-Stamper",
+                ["LastModifiedBy"] = "alice@contoso.com"
+            });
+
+        Dictionary<string, string>? capturedTags = null;
+        _tagService
+            .Setup(x => x.SetTagsAsync(resourceId, It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .Callback<string, Dictionary<string, string>, CancellationToken>((_, tags, _) => capturedTags = tags)
+            .ReturnsAsync(true);
+
+        var orchestrator = CreateOrchestrator();
+        var evt = new ResourceEvent { ResourceId = resourceId, Caller = "alice@contoso.com" };
+
+        await orchestrator.ProcessAsync(evt);
+
+        // LastModifiedBy should NOT be in the applied set since value is unchanged
+        // But LastModifiedOn (timestamp) WILL be applied since it always differs
+        if (capturedTags is not null)
+        {
+            Assert.False(capturedTags.ContainsKey("LastModifiedBy"),
+                "LastModifiedBy should be skipped when value is unchanged");
+        }
+    }
+
+    [Fact]
+    public async Task AppliesOverwriteTag_WhenValueDiffers()
+    {
+        var resourceId = "/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1";
+        _tagService
+            .Setup(x => x.GetTagsAsync(resourceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, string>
+            {
+                ["Creator"] = "bob@contoso.com",
+                ["CreatedOn"] = "2026-01-01T00:00:00Z",
+                ["StampedBy"] = "Az-Stamper",
+                ["LastModifiedBy"] = "bob@contoso.com"
+            });
+
+        Dictionary<string, string>? capturedTags = null;
+        _tagService
+            .Setup(x => x.SetTagsAsync(resourceId, It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+            .Callback<string, Dictionary<string, string>, CancellationToken>((_, tags, _) => capturedTags = tags)
+            .ReturnsAsync(true);
+
+        var orchestrator = CreateOrchestrator();
+        var evt = new ResourceEvent { ResourceId = resourceId, Caller = "alice@contoso.com" };
+
+        await orchestrator.ProcessAsync(evt);
+
+        Assert.NotNull(capturedTags);
+        Assert.True(capturedTags.ContainsKey("LastModifiedBy"),
+            "LastModifiedBy should be applied when value differs");
+        Assert.Equal("alice@contoso.com", capturedTags["LastModifiedBy"]);
+    }
 }


### PR DESCRIPTION
## Summary
- **Bug**: The stamper's tag writes fired Event Grid events that it processed again, creating a ~10 min cascade. Resources were re-tagged up to 14 times in 2.5 hours with the function app's own identity (`func-azstamper-pcxd`).
- **Fix**: Three layers of defense — auto-detect self identity via `WEBSITE_SITE_NAME` (zero-config), skip no-op tag writes when values match, keep existing `SelfPrincipalId` fast-path.
- **5 new tests** covering self-app-name detection (including case insensitivity) and value comparison logic.

## Test plan
- [x] All 67 unit tests pass (`dotnet test`)
- [ ] Deploy to Procentrix Dev and verify activity log shows no more self-triggered re-tagging
- [ ] Confirm legitimate user changes still produce correct `LastModifiedBy`/`LastModifiedOn` tags
- [ ] Confirm first-stamp behavior unchanged (no `LastModifiedBy`/`LastModifiedOn` on creation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)